### PR TITLE
mesh_com ROS node 0.3.2

### DIFF
--- a/modules/mesh_com/mesh_com/mesh_executor.py
+++ b/modules/mesh_com/mesh_com/mesh_executor.py
@@ -145,21 +145,21 @@ class MeshNetwork:
 
         try:
             parameters = json.loads(msg)
-            self.settings.api_version = parameters["api_version"]
-            self.settings.ssid = parameters["ssid"]
-            self.settings.key = parameters["key"]
-            self.settings.ap_mac = parameters["ap_mac"]
-            self.settings.country = parameters["country"].lower()
-            self.settings.frequency = parameters["frequency"]
-            self.settings.ip = parameters["ip"]
-            self.settings.subnet = parameters["subnet"]
-            self.settings.tx_power = parameters["tx_power"]
-            self.settings.mode = parameters["mode"]
-            # self.settings.enc = parameters["enc"]
-        except json.decoder.JSONDecodeError or KeyError or Exception:
-            syslog.syslog('Setting Failed')
-            pass
-        self.__change_configuration()
+            self.settings.api_version = int(parameters["api_version"])
+            self.settings.ssid = str(parameters["ssid"])
+            self.settings.key = str(parameters["key"])
+            self.settings.ap_mac = str(parameters["ap_mac"])
+            self.settings.country = str(parameters["country"]).lower()
+            self.settings.frequency = str(parameters["frequency"])
+            self.settings.ip = str(parameters["ip"])
+            self.settings.subnet = str(parameters["subnet"])
+            self.settings.tx_power = str(parameters["tx_power"])
+            self.settings.mode = str(parameters["mode"])
+            # self.settings.enc = str(parameters["enc"])
+            self.__change_configuration()
+        except (json.decoder.JSONDecodeError or KeyError or
+                TypeError or AttributeError) as e:
+            syslog.syslog("JSON format not correct\n" + e)
 
     def __change_configuration(self):
         # api 1, ad-hoc

--- a/modules/mesh_com/mesh_com/mesh_executor.py
+++ b/modules/mesh_com/mesh_com/mesh_executor.py
@@ -159,7 +159,8 @@ class MeshNetwork:
             self.__change_configuration()
         except (json.decoder.JSONDecodeError or KeyError or
                 TypeError or AttributeError) as e:
-            syslog.syslog("JSON format not correct\n" + e)
+            syslog.syslog("JSON format not correct")
+            syslog.syslog(str(e))
 
     def __change_configuration(self):
         # api 1, ad-hoc

--- a/modules/mesh_com/package.xml
+++ b/modules/mesh_com/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mesh_com</name>
-  <version>0.3.1</version>
+  <version>0.3.2</version>
   <description>ROS Mesh Node</description>
   <maintainer email="mika.joenpera@unikie.com">joenpera</maintainer>
   <license>BSD 3-Clause License</license>


### PR DESCRIPTION
- JSON configuration format checks added
- informative syslog output added for errors
- not crashing whole executor anymore with wrong JSON format
- mesh_com ROS node version changed to 0.3.2