### PR TITLE
User and mesh configuration is now taken from mesh_com.conf yaml file.

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/mesh_com.conf
+++ b/modules/sc-mesh-secure-deployment/src/mesh_com.conf
@@ -1,0 +1,27 @@
+---
+debug: True
+client:
+    set_hostname: True
+    disable_networking: True
+
+server:
+    ubuntu:
+      api_version: 1                  # interface version for future purposes
+      ssid: "gold"                    # 0-32 octets, UTF-8, shlex.quote chars limiting
+      key: "1234567890"               # key for the network
+      enc: "wep"                      # encryption (none wep, wpa2, wpa3, sae)
+      ap_mac: "00:11:22:33:44:55"     # bssid for mesh network
+      country: "fi"                   # Country code, sets tx power limits and supported channels
+      frequency: 5180                 # 5180 wifi channel frequency, depends on the country code and HW
+      subnet: 255.255.255.0           # subnet mask
+      tx_power: 30                    # select 30dBm, HW and regulations limiting it correct level. Can be used to set lower dBm levels for testing purposes (e.g. 5dBm)
+      mode: "mesh"                    # mesh=mesh network, ap=debug hotspot
+      type: "ibss"                    # 11s or ibss
+    openwrt:
+      batadv: 120
+      babeld: 17
+      bmx7: 18
+      ieee80211s_mesh_id: ssrc
+      ieee80211s_mesh_fwding: 0
+      channel: 5
+      gateway: False


### PR DESCRIPTION
Moved the client and server mesh configuration settings to a configuration file (rather than being hardcoded in json in server-mesh.py)

- Added 'type' to configuration (11s or ibss). The corresponding script is now copied over on the client.
- Added a 'debug' configuration setting
- Added some client conf for set_hostname and disable_networking (useful for running a client on a dev machine if you don't want to mess up the hostname/networking)
- Modified the way that the client gets the unencrypted json from the server by concatenating the list and parsing for json using regex. Allows unlimited # of fields to be addded/sent from the server.