### PR TITLE
mesh_com: debian removal script added

### DIFF
--- a/modules/mesh_com/debian/prerm
+++ b/modules/mesh_com/debian/prerm
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -e /usr/lib/NetworkManager/conf.d/unamaged_wifi_interfaces.conf ]; then
+    rm /usr/lib/NetworkManager/conf.d/unamaged_wifi_interfaces.conf
+fi

--- a/modules/mesh_com/package.xml
+++ b/modules/mesh_com/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mesh_com</name>
-  <version>0.3.3</version>
+  <version>0.3.4</version>
   <description>ROS Mesh Node</description>
   <maintainer email="mika.joenpera@unikie.com">joenpera</maintainer>
   <license>BSD 3-Clause License</license>


### PR DESCRIPTION
prerm script added to handle uninstallation ("dpkg -r ros-foxy-mesh-com" ).
Version number bumped.