### PR TITLE
mesh_com: scan station interface for ssid selection

### DIFF
--- a/modules/sc-mesh-secure-deployment/configure.sh
+++ b/modules/sc-mesh-secure-deployment/configure.sh
@@ -46,11 +46,24 @@ function menu_from_array()
   done
 }
 
+function get_SSID() {
+  local ssid_list
+  #declare -A ssid_array
+  while read -r ssid_list; do
+         [[ "${ssid_list//'SSID: '*}" == '' ]] && ssid="${ssid_list/'SSID: '}" && ssid_array+=($ssid)
+  done
+}
 
 #-----------------------------------------------------------------------------#
 function ap_connect {
-echo '> Connecting to Access Point...'
-read -p "- SSID: " ssid
+echo '> Please choose from the list of available interfaces...'
+interfaces_arr=($(ip link | awk -F: '$0 !~ "lo|vir|doc|eth|bat|^[^0-9]"{print $2}'))
+menu_from_array "${interfaces_arr[@]}"
+sta_if=$choice
+get_SSID <<< "$(iw $sta_if scan)"
+echo '> scanning available Access Point, select ssid from scan list...'
+menu_from_array "${ssid_array[@]}"
+ssid=$choice
 read -p "- Password: " password
 cat <<EOF > conf/ap.conf
 network={
@@ -58,11 +71,10 @@ network={
   psk="$password"
 }
 EOF
-echo '> Please choose from the list of available interfaces...'
-interfaces_arr=($(ip link | awk -F: '$0 !~ "lo|vir|doc|eth|bat|^[^0-9]"{print $2}'))
-menu_from_array "${interfaces_arr[@]}"
-sudo wpa_supplicant -B -i $choice -c conf/ap.conf
-sudo dhclient -v $choice
+echo '> Connecting to Access Point:'
+echo $ssid
+sudo wpa_supplicant -B -i $sta_if -c conf/ap.conf
+sudo dhclient -v $sta_if
 }
 
 function ap_create {


### PR DESCRIPTION
scan selected STA interface to make sure that user selects
available access point for reliablity.

Example:
sudo modules/sc-mesh-secure-deployment/configure.sh -ap
=== sc-mesh-secure-deployment-configure ===
> Do you wish to...
1) Connect to an Access Point?
2) Create an Access Point?
3) Remove an Access Point?
> Please choose from the list of available interfaces...
1) wlan0
> scanning available Access Point, select ssid from scan list...
1) Test	     3) JioFiber-2G
2) Paraskhush_2.4    4) Amal
- Password: xxxxxx

Signed-off-by: Govind Singh <govind.sk85@gmail.com>
Signed-off-by: Govind Singh <govind@ssrc.tii.ae>