### PR TITLE
mesh_com:utils: Add phy parameter monitoring utility infra

### DIFF
--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -1,3 +1,4 @@
+import argparse
 import getopt
 import sys
 import datetime
@@ -31,22 +32,19 @@ def log_rssi():
         sleep(rssi_mon_interval)
 
 if __name__=='__main__':
-    argv = sys.argv[1:]
 
-    try:
-        opts, args = getopt.getopt(argv, "hr:i:")
-        for opt, arg in opts:
-            if opt in ['-h']:
-                print ("monitor_phy_param.py -r period -i interface")
-                sys.exit()
-            elif opt in ['-r']:
-                print ("rssi mon period:", arg)
-                rssi_mon_interval = int(arg)
-            elif opt in ['-i']:
-                print ("interface:", arg)
-                interface = arg
-    except getopt.error as err:
-        print (str(err))
+    # Construct the argument parser
+    phy_cfg = argparse.ArgumentParser()
+
+    # Add the arguments to the parser
+    phy_cfg.add_argument("-r", "--rssi_period", required=True, help="RSSI monitoring period Ex: 5 (equals to 5 sec)")
+    phy_cfg.add_argument("-i", "--interface", required=True)
+    args = phy_cfg.parse_args()
+
+    #populate args
+    rssi_mon_interval = int(args.rssi_period)
+    interface = args.interface
+
 
     Thread(target=log_rssi).start()
 

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -15,6 +15,8 @@ import re
 def is_csi_supported():
     global csi_type
     global debug
+    global serial_port
+
     print(csi_type)
     if (csi_type == 'nexmon'):
         soc_version_cmd = "cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}'"
@@ -28,7 +30,7 @@ def is_csi_supported():
         else:
             return 0
     elif (csi_type == 'esp'):
-        ser=serial.Serial('/dev/ttyUSB0', 115200, timeout=1)
+        ser=serial.Serial('/dev/' + serial_port, 115200, timeout=1)
         ser.flush()
         while True:
             try:
@@ -127,6 +129,7 @@ if __name__=='__main__':
     mac_addr_filter = conf['mac_addr_filter']
     channel = conf['channel']
     bandwidth = conf['bandwidth']
+    serial_port = conf['serial_port']
     #populate args
     rssi_mon_interval = int(args.rssi_period)
     interface = args.interface

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -16,6 +16,8 @@ def is_csi_supported():
     global csi_type
     global debug
     global serial_port
+    global csi_max_records
+    no_csi_record = 0
 
     print(csi_type)
     if (csi_type == 'nexmon'):
@@ -38,6 +40,10 @@ def is_csi_supported():
                 if re.search('CSI', data):
                     with open("esp_csi_data.txt", "a") as f:
                         f.write(data)
+                        no_csi_record += 1
+                        if (no_csi_record == csi_max_record):
+                            ser.close()
+                            break
             except:
                 break
         return 0
@@ -130,6 +136,8 @@ if __name__=='__main__':
     channel = conf['channel']
     bandwidth = conf['bandwidth']
     serial_port = conf['serial_port']
+    csi_max_records = conf['csi_max_records']
+
     #populate args
     rssi_mon_interval = int(args.rssi_period)
     interface = args.interface

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -1,0 +1,52 @@
+import getopt
+import sys
+import datetime
+import subprocess
+from time import sleep
+from threading import Thread
+
+#defult rssi monitoring interval: 5sec
+rssi_mon_interval = 5
+#defualt interface
+interface = "wlan0"
+
+def get_rssi():
+    global interface
+    cmd = "iw dev " + interface + " station dump | grep 'signal:' | awk '{print $2}'"
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    rssi = proc.communicate()[0].decode('utf-8')
+    return rssi
+
+def log_rssi():
+    global rssi_mon_interval
+    fn_suffix=str(datetime.datetime.now())
+    log_file_path = '/var/log/'
+    log_file_name =  'rssi'+fn_suffix+'.txt'
+    while True:
+        f = open(log_file_path+log_file_name, 'a')
+        rssi_sta = get_rssi()
+        print(rssi_sta)
+        f.write(rssi_sta)
+        f.close()
+        sleep(rssi_mon_interval)
+
+if __name__=='__main__':
+    argv = sys.argv[1:]
+
+    try:
+        opts, args = getopt.getopt(argv, "hr:i:")
+        for opt, arg in opts:
+            if opt in ['-h']:
+                print ("monitor_phy_param.py -r period -i interface")
+                sys.exit()
+            elif opt in ['-r']:
+                print ("rssi mon period:", arg)
+                rssi_mon_interval = int(arg)
+            elif opt in ['-i']:
+                print ("interface:", arg)
+                interface = arg
+    except getopt.error as err:
+        print (str(err))
+
+    Thread(target=log_rssi).start()
+

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -32,13 +32,15 @@ def is_csi_supported():
         else:
             return 0
     elif (csi_type == 'esp'):
+        filepath = "/var/log/"
+        filename = "esp_csi_data-%m_%d_%Y_%H_%M_%S.txt"
         ser=serial.Serial('/dev/' + serial_port, 115200, timeout=1)
         ser.flush()
         while True:
             try:
                 data = ser.readline().decode('utf-8')
                 if re.search('CSI', data):
-                    with open("esp_csi_data.txt", "a") as f:
+                    with open(filepath+filename, "a") as f:
                         f.write(data)
                         no_csi_record += 1
                         if (no_csi_record == csi_max_record):

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -2,6 +2,7 @@ import argparse
 import getopt
 import sys
 import datetime
+import time
 import subprocess
 from time import sleep
 from threading import Thread
@@ -20,14 +21,14 @@ def get_rssi():
 
 def log_rssi():
     global rssi_mon_interval
-    fn_suffix=str(datetime.datetime.now())
+    fn_suffix=str(datetime.datetime.now().strftime('%m_%d_%Y_%H_%M_%S'))
     log_file_path = '/var/log/'
     log_file_name =  'rssi'+fn_suffix+'.txt'
     while True:
         f = open(log_file_path+log_file_name, 'a')
         rssi_sta = get_rssi()
         print(rssi_sta)
-        f.write(rssi_sta)
+        f.write(str(time.time())+' '+rssi_sta)
         f.close()
         sleep(rssi_mon_interval)
 

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -6,9 +6,9 @@ import subprocess
 from time import sleep
 from threading import Thread
 
-#defult rssi monitoring interval: 5sec
+#default rssi monitoring interval: 5sec
 rssi_mon_interval = 5
-#defualt interface
+#default interface
 interface = "wlan0"
 
 def get_rssi():

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -9,6 +9,8 @@ from threading import Thread
 from getmac import get_mac_address
 from netaddr import *
 import yaml
+import serial
+import re
 
 def is_csi_supported():
     global csi_type
@@ -26,6 +28,16 @@ def is_csi_supported():
         else:
             return 0
     elif (csi_type == 'esp'):
+        ser=serial.Serial('/dev/ttyUSB0', 115200, timeout=1)
+        ser.flush()
+        while True:
+            try:
+                data = ser.readline().decode('utf-8')
+                if re.search('CSI', data):
+                    with open("esp_csi_data.txt", "a") as f:
+                        f.write(data)
+            except:
+                break
         return 0
     else:
         return 0;

--- a/modules/utils/monitor_phy_param.py
+++ b/modules/utils/monitor_phy_param.py
@@ -6,11 +6,19 @@ import time
 import subprocess
 from time import sleep
 from threading import Thread
+from getmac import get_mac_address
+from netaddr import *
 
 #default rssi monitoring interval: 5sec
 rssi_mon_interval = 5
 #default interface
 interface = "wlan0"
+
+def get_mac_oui():
+    mac = EUI(get_mac_address(interface))
+    oui = mac.oui
+    print(oui.registration().address)
+    return oui
 
 def get_rssi():
     global interface
@@ -45,7 +53,7 @@ if __name__=='__main__':
     #populate args
     rssi_mon_interval = int(args.rssi_period)
     interface = args.interface
-
+    get_mac_oui()
 
     Thread(target=log_rssi).start()
 

--- a/modules/utils/phy_param.conf
+++ b/modules/utils/phy_param.conf
@@ -3,8 +3,14 @@ debug: True
 #Supported formats are "nexmom", "esp", "ath"
 csi: True
 csi_format: "nexmon"
-rssi: True
-rssi_avg: True
+rssi: False
+rssi_avg: False
 rssi_poll_interval: 5
+#csi or rssi monitoring interface
 interface: "wlan0"
-mac_addr_filter: "FF:FF:FF:FF:FF:FF"
+#source mac addr of the rx frame
+mac_addr_filter: "d8:32:e3:7d:e3:f1"
+#monitoring channel
+channel: 36
+#bandwidth of the monitoring link, ex: 20/40/80
+bandwidth: 80

--- a/modules/utils/phy_param.conf
+++ b/modules/utils/phy_param.conf
@@ -14,3 +14,5 @@ mac_addr_filter: "d8:32:e3:7d:e3:f1"
 channel: 36
 #bandwidth of the monitoring link, ex: 20/40/80
 bandwidth: 80
+# serial port config is only applicable for ESP CSI format
+serial_port: "ttyUSB0"

--- a/modules/utils/phy_param.conf
+++ b/modules/utils/phy_param.conf
@@ -16,3 +16,4 @@ channel: 36
 bandwidth: 80
 # serial port config is only applicable for ESP CSI format
 serial_port: "ttyUSB0"
+csi_max_records: 5

--- a/modules/utils/phy_param.conf
+++ b/modules/utils/phy_param.conf
@@ -2,7 +2,7 @@
 debug: True
 #Supported formats are "nexmom", "esp", "ath"
 csi: True
-csi_format: "nexmon"
+csi_format: "esp"
 rssi: False
 rssi_avg: False
 rssi_poll_interval: 5

--- a/modules/utils/phy_param.conf
+++ b/modules/utils/phy_param.conf
@@ -1,0 +1,10 @@
+---
+debug: True
+#Supported formats are "nexmom", "esp", "ath"
+csi: True
+csi_format: "nexmon"
+rssi: True
+rssi_avg: True
+rssi_poll_interval: 5
+interface: "wlan0"
+mac_addr_filter: "FF:FF:FF:FF:FF:FF"


### PR DESCRIPTION
Add utility infra to capture or periodically monitor/log various
mac/phy parameter that includes radio rssi, CSI, BW, RF temperature,
PER, peer stats etc.

This change adds RSSI monitoring support on a given interface with
configurable periodicity.

uses:monitor_phy_param.py -r period -i interface
log file: /var/logs/rssi2021-06-29 10:53:34.833729.txt

Signed-off-by: Govind Singh <govind.sk85@gmail.com>
Signed-off-by: Govind Singh <govind@ssrc.tii.ae>