### PR TITLE
Setup fastrtps profile with mesh whitelisting address

### DIFF
--- a/modules/mesh_com/mesh_com/mesh_executor.py
+++ b/modules/mesh_com/mesh_com/mesh_executor.py
@@ -183,6 +183,10 @@ class MeshNetwork:
                              quote(self.settings.tx_power),
                              quote(self.settings.country)])
 
+            if os.path.exists("/opt/ros/foxy/setup_ros_profiles.sh"):
+                subprocess.call(["/opt/ros/foxy/setup_ros_profiles.sh",
+                                 quote(self.settings.ip)])
+
         syslog.syslog('Setting Done')
 
     def __handle_report_request(self):


### PR DESCRIPTION
ROS2 data distribution system discovery mechanism publishes topic
information by default to all network interfaces available in the
system. To avoid that the fastrtps profile needs to be updated to
define ip addresses for the interfaces allowed to be used for ROS2
topic communication.