### PR TITLE
mesh_parameters subscriber qos change

### DIFF
--- a/modules/mesh_com/mesh_com/mesh_subscriber.py
+++ b/modules/mesh_com/mesh_com/mesh_subscriber.py
@@ -1,7 +1,9 @@
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import QoSPresetProfiles
-
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSHistoryPolicy
 from std_msgs.msg import String
 import socket
 
@@ -9,11 +11,16 @@ import socket
 class MeshSubscriber(Node):
     def __init__(self):
         super().__init__('mesh_subscriber')
+        qos = QoSProfile(
+            depth=1,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+
         self.subscription = self.create_subscription(
             String,
             'mesh_parameters',
             self.listener_callback,
-            QoSPresetProfiles.SYSTEM_DEFAULT.value)
+            qos)
         self.subscription  # prevent unused variable warning
         self.HOST = '127.0.0.1'  # Standard loopback interface address (localhost)
         self.PORT = 33221  # Port to listen on (non-privileged ports are > 1023)


### PR DESCRIPTION
To verify that mesh_parameters are delivered reliably and the param message remains in the topic history even if the subscriber is create/established after the mesh_parameters message is published bu communication_link, the topic QoS settings needs to be defined to allow this behavior. As communication_link already publish to the topic with reliable way, the mesh_clom shall also subscribe the topic with same qos parameters to be able to read the message at all.

This PR changes the subscriber QoS to be align with Qos set by publisher in communication_link.
