### PR TITLE
mesh_com: device_noise_dict KeyError crash fix

### DIFF
--- a/common/scripts/mesh-11s.sh
+++ b/common/scripts/mesh-11s.sh
@@ -158,9 +158,9 @@ EOF
       # This is likely due to the interface not being up in time, and will
       # require some fiddling with the systemd startup order.
       if [[ -z "${10}" ]]; then
-        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-11s.conf -D nl80211 -C /var/run/wpa_supplicant/ -B
+        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-11s.conf -D nl80211 -C /var/run/wpa_supplicant/ -B -f /tmp/wpa_supplicant_11s.log
       else
-        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-11s.conf -D nl80211 -C /var/run/wpa_supplicant/
+        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-11s.conf -D nl80211 -C /var/run/wpa_supplicant/ -f /tmp/wpa_supplicant_11s.log
       fi
       ;;
 
@@ -247,7 +247,7 @@ EOF
       #TODO
       # dhserver
 
-      wpa_supplicant -B -i "$wifidev" -c /var/run/wpa_supplicant-ap.conf -D nl80211 -C /var/run/wpa_supplicant/
+      wpa_supplicant -B -i "$wifidev" -c /var/run/wpa_supplicant-ap.conf -D nl80211 -C /var/run/wpa_supplicant/ -f /tmp/wpa_supplicant_ap.log
 
       ;;
 

--- a/common/scripts/mesh-ibss.sh
+++ b/common/scripts/mesh-ibss.sh
@@ -155,9 +155,9 @@ EOF
       # This is likely due to the interface not being up in time, and will
       # require some fiddling with the systemd startup order.
       if [[ -z "${10}" ]]; then
-        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-adhoc.conf -D nl80211 -C /var/run/wpa_supplicant/ -B
+        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-adhoc.conf -D nl80211 -C /var/run/wpa_supplicant/ -B -f /tmp/wpa_supplicant_ibss.log
       else
-        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-adhoc.conf -D nl80211 -C /var/run/wpa_supplicant/
+        wpa_supplicant -i "$wifidev" -c /var/run/wpa_supplicant-adhoc.conf -D nl80211 -C /var/run/wpa_supplicant/ -f /tmp/wpa_supplicant_ibss.log
       fi
       ;;
 
@@ -244,7 +244,7 @@ EOF
       #TODO
       # dhserver
 
-      wpa_supplicant -B -i "$wifidev" -c /var/run/wpa_supplicant-ap.conf -D nl80211 -C /var/run/wpa_supplicant/
+      wpa_supplicant -B -i "$wifidev" -c /var/run/wpa_supplicant-ap.conf -D nl80211 -C /var/run/wpa_supplicant/ -f /tmp/wpa_supplicant_ap.log
 
       ;;
 

--- a/modules/mesh_com/mesh_com/src/batstat.py
+++ b/modules/mesh_com/mesh_com/src/batstat.py
@@ -135,7 +135,7 @@ class Batman:
 
     def _update_iw_type(self):
         """
-        Update device self.country code
+        Update device self.status code
 
         :return: None
         """
@@ -234,7 +234,7 @@ class Batman:
         self.topology = {'status': self.status,  # "MESH/OFF/NO_CONFIG/ONGOING/AP/"
                          'my_mac': self._get_my_mac,  # e.g. 00:11:22:33:44:55
                          'noise': self.device_noise_dict[self.freq]
-                         if self.freq != self.mesh_status.not_avail
+                         if self.freq in self.device_noise_dict
                          else self.mesh_status.not_avail,
                          'freq': self.freq,
                          'txpower': self.txpower,

--- a/modules/mesh_com/package.xml
+++ b/modules/mesh_com/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mesh_com</name>
-  <version>0.4.1</version>
+  <version>0.4.2</version>
   <description>ROS Mesh Node</description>
   <maintainer email="mika.joenpera@unikie.com">joenpera</maintainer>
   <license>BSD 3-Clause License</license>


### PR DESCRIPTION
batstat crash fix.  Noise value availability check was not correct.

- minor comment fix
- mesh-11s.sh and mesh-ibss.sh wpa_supplicant logging added

Bug-Id: DP-1348 (internal system)

Signed-off-by: Mika Joenpera <mika.joenpera@unikie.com>