### PR TITLE
mesh_com: Update only cryptolib submodule

### DIFF
--- a/modules/sc-mesh-secure-deployment/install.sh
+++ b/modules/sc-mesh-secure-deployment/install.sh
@@ -92,4 +92,5 @@ if [ $? -ne 0 ]; then
 fi
 echo "> Init submodules..."
 cd mesh_com
-git submodule update --init --recursive
+#git submodule update --init --recursive
+git submodule update --init common/security/cryptolib


### PR DESCRIPTION
Update only required submodule as some of the
unused submodule update is causing failure in cloning of
required submodules.

Signed-off-by: Govind Singh <govind.sk85@gmail.com>
Signed-off-by: Govind Singh <govind@ssrc.tii.ae>