### PR TITLE
Multipurpose Mesh test case added

### DIFF
--- a/common/tests/functional/check_BSS_list.sh
+++ b/common/tests/functional/check_BSS_list.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./common.sh
+source ./common/common.sh
 
 test_case="check BSS list in scan results of 2.4/5GHZ MBSS"
 

--- a/common/tests/functional/check_BSS_list.sh
+++ b/common/tests/functional/check_BSS_list.sh
@@ -16,7 +16,7 @@ uniq_frequencies=""
 # Arguments:
 #######################################
 _init() {
-
+  _deinit
   echo "$0, init called" | print_log
 	# detect_wifi
 	# multiple wifi options --> can be detected as follows:
@@ -31,6 +31,8 @@ _init() {
     result=$FAIL
     return
   fi
+
+  ifconfig $wifidev up
 
 	# Create wpa_supplicant.conf here if needed
 }
@@ -98,6 +100,19 @@ _result() {
 }
 
 #######################################
+# DeInit
+# Globals:
+#  device_list
+# Arguments:
+#######################################
+_deinit() {
+  echo "$0, deinit called" | print_log
+
+  killall iperf3
+  killall wpa_supplicant
+}
+
+#######################################
 # main
 # Globals:
 #  result
@@ -130,6 +145,8 @@ main() {
   	echo "PASSED  : $test_case" | print_log result
    	exit 0
   fi
+
+  _deinit
 }
 
 main

--- a/common/tests/functional/check_channel_list.sh
+++ b/common/tests/functional/check_channel_list.sh
@@ -17,7 +17,7 @@ used_channels="2412 2417 2422 2427 2432 2437 2442 2447 2452 2457 2462 5180 5200 
 # Arguments:
 #######################################
 _init() {
-
+  _deinit
   echo "$0, init called" | print_log
 	# detect_wifi
 	# multiple wifi options --> can be detected as follows:
@@ -84,6 +84,19 @@ _result() {
 }
 
 #######################################
+# DeInit
+# Globals:
+#  device_list
+# Arguments:
+#######################################
+_deinit() {
+  echo "$0, deinit called" | print_log
+
+  killall iperf3
+  killall wpa_supplicant
+}
+
+#######################################
 # main
 # Globals:
 #  result
@@ -116,6 +129,8 @@ main() {
   	echo "PASSED  : $test_case" | print_log result
    	exit 0
   fi
+
+  _deinit
 }
 
 main

--- a/common/tests/functional/check_channel_list.sh
+++ b/common/tests/functional/check_channel_list.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./common.sh
+source ./common/common.sh
 
 test_case="check available channels in 2.4/5GHZ"
 

--- a/common/tests/functional/common.sh
+++ b/common/tests/functional/common.sh
@@ -5,6 +5,9 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+# trap ctrl-c and call ctrl_c()
+trap ctrl_c INT
+
 # Global constants
 readonly log_file="./functional_tests_debug.log"
 readonly results_file="./functional_tests_results.log"
@@ -20,6 +23,39 @@ wifidev=0           # Should be updated from test script
 device_list=0       # includes wifi phy list when find_wifi_device() is called
 channel_list=0      # includes supported wifi channels when update_channel_list() is called
 
+#######################################
+# ctrl-c trap
+# Globals:
+# Arguments:
+#######################################
+function ctrl_c() {
+  echo "** Trapped CTRL-C"
+  exit 0
+}
+
+#######################################
+# Set Batman OGM interval
+# Globals:
+# Arguments:
+#######################################
+set_batman_orig_interval() {
+  if ! batctl orig_interval $1; then
+    echo "Batman orig_interval setting failed!!"
+  fi
+}
+
+#######################################
+# Set Batman routing algorithm
+# Globals:
+# Arguments:
+#######################################
+ set_batman_routing_algo(){
+  if ! batctl ra $1; then
+    echo "Batman routing algo setting failed!!"
+    echo "Batman-adv Kernel configuration might not be correct."
+  fi
+
+ }
 #######################################
 # Add date prefix to line and write to log
 # Globals:
@@ -58,6 +94,7 @@ update_channel_list() {
 #  $1 = config file name
 #  $2 = frequency
 #  $3 = NONE/SAE
+#  $4 = country
 #######################################
 create_wpa_supplicant_config() {
   cat <<EOF > "$1"
@@ -65,7 +102,7 @@ ctrl_interface=DIR=/var/run/wpa_supplicant
 # use 'ap_scan=2' on all devices connected to the network
 # this is unnecessary if you only want the network to be created when no other networks..
 ap_scan=1
-country=AE
+country=$4
 p2p_disabled=1
 network={
   ssid="test_case_run"

--- a/common/tests/functional/common/common.sh
+++ b/common/tests/functional/common/common.sh
@@ -39,7 +39,9 @@ function ctrl_c() {
 # Arguments:
 #######################################
 set_batman_orig_interval() {
-  if ! batctl orig_interval $1; then
+  batctl orig_interval "$1"
+  ret=$?
+  if [ "$ret" != 0 ]; then
     echo "Batman orig_interval setting failed!!"
   fi
 }
@@ -50,7 +52,9 @@ set_batman_orig_interval() {
 # Arguments:
 #######################################
  set_batman_routing_algo(){
-  if ! batctl ra $1; then
+  batctl ra "$1"
+  ret=$?
+  if [ "$ret" != 0 ]; then
     echo "Batman routing algo setting failed!!"
     echo "Batman-adv Kernel configuration might not be correct."
   fi
@@ -185,7 +189,7 @@ wait_ip(){
   server_wait=1
   echo -n "waiting for $1 ..."
   while [ "$server_wait" -eq 1 ]; do
-    if ping -c 1 -w 2 $1 &> /dev/null; then
+    if ping -c 1 -w 2 "$1" &> /dev/null; then
       echo "$1 is online!"
       server_wait=0
     else

--- a/common/tests/functional/common/common.sh
+++ b/common/tests/functional/common/common.sh
@@ -181,12 +181,15 @@ exe() {
 
 #######################################
 # Wait IP address until it is online
+#  - will timeout after ~60seconds
 # Globals:
 # Arguments:
 #  $1 = IP address to wait
 #######################################
 wait_ip(){
   server_wait=1
+  timeout=0;
+
   echo -n "waiting for $1 ..."
   while [ "$server_wait" -eq 1 ]; do
     if ping -c 1 -w 2 "$1" &> /dev/null; then
@@ -194,6 +197,11 @@ wait_ip(){
       server_wait=0
     else
       echo -n "."
+      ((timeout=timeout+2))
+      if [ "$timeout" -gt 60 ]; then
+        echo "Timeout when waiting $1!"
+        exit 0  # no reason to continue as target IP is not in network
+      fi
     fi
   done
 }

--- a/common/tests/functional/template.sh
+++ b/common/tests/functional/template.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./common.sh
+source ./common/common.sh
 
 test_case="test case name from excel"
 

--- a/common/tests/functional/template.sh
+++ b/common/tests/functional/template.sh
@@ -26,9 +26,9 @@ _init() {
 	# devices = 0x0034 0x003c 9462/988x  11s
 	#           0x003e        6174       adhoc
 	#           0x0033        Doodle
-	find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e"
-	phyname=${device_list[0]}  # only first pci device is used here
-	wifidev="mesh0"
+  find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e"
+  phyname=${device_list[0]}  # only first pci device is used here
+  wifidev="mesh0"
   if ! iw phy $phyname interface add $wifidev type mp; then
     result=$FAIL
     return
@@ -50,13 +50,12 @@ _test() {
 
   # my_command executed and pass logs to logs/-folder
   ret=$?
-	if [ "$ret" != 0 ]; then
-	  result=$FAIL
-	  return
-	else
-	  result=$PASS
-	fi
-
+  if [ "$ret" != 0 ]; then
+    result=$FAIL
+    return
+  else
+    result=$PASS
+  fi
 }
 
 #######################################
@@ -73,11 +72,11 @@ _result() {
   # add here
 
 	#2 make decision ($PASS or $FAIL)
-	if [ 1 -gt 0 ]; then
-		result=$PASS
-	else
-	  result=$FAIL
-	fi
+  if [ 1 -gt 0 ]; then
+    result=$PASS
+  else
+    result=$FAIL
+  fi
 }
 
 #######################################
@@ -117,15 +116,15 @@ main() {
   _init "$ipaddress"
 
   if [ "$result" -eq "$FAIL" ]; then
-  	echo "FAILED  _init: $test_case" | print_log result
-  	exit 0
+    echo "FAILED  _init: $test_case" | print_log result
+   exit 0
   fi
 
   _test
 
   if [ "$result" -eq "$FAIL" ]; then
-  	echo "FAILED  _test: $test_case" | print_log result
-  	exit 0
+    echo "FAILED  _test: $test_case" | print_log result
+    exit 0
   fi
 
   _result
@@ -134,7 +133,7 @@ main() {
    	echo "FAILED  : $test_case" | print_log result
    	exit 0
   else
-  	echo "PASSED  : $test_case" | print_log result
+    echo "PASSED  : $test_case" | print_log result
    	exit 0
   fi
 }

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -26,9 +26,9 @@ _init() {
 	# devices = 0x0034 0x003c 9462/988x  11s
 	#           0x003e        6174       adhoc
 	#           0x0033        Doodle
-	find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e 0x0033"
-	phyname=${device_list[0]}  # only first pci device is used here
-	wifidev="mesh0"
+  find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e 0x0033"
+  phyname=${device_list[0]}  # only first pci device is used here
+  wifidev="mesh0"
   if ! iw phy $phyname interface add $wifidev type mp; then
     result=$FAIL
     return

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -136,13 +136,13 @@ _result() {
   echo -e "# UDP result:\n$udp_result" | print_log result
   udp_avg=$(awk -F " " '($NF=="sender") {print $7}' logs/udp.log)
 
-  ping_result=$(grep rtt -B1 logs/ping.log)
+  ping_result=$(grep -e rtt -e round-trip -B1 logs/ping.log)
   echo -e "# ping result:\n$ping_result" | print_log result
-  ping_avg=$(echo "$ping_result" | grep rtt | cut -d '/' -f 5)
+  ping_avg=$(echo "$ping_result" | grep -e rtt -e round-trip | cut -d ' ' -f 4 | cut -d '/' -f 2)
 
 	#2 make decision ($PASS or $FAIL)
 
-  # ping limit 4.0milliseconds
+  # ping limit 3.0milliseconds
   if (( $(echo "$ping_avg < 3.0" |bc -l) )); then
     result=$PASS
   else

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./common.sh
+source ./common/common.sh
 
 test_case="Mesh connection and Iperf/ping-N hop"
 
@@ -234,7 +234,7 @@ main() {
      [ "$ipaddress" = "255.255.255.255" ] || \
      [ "$encryption" = "NA" ]; then
     echo "
-        Usage: sudo $0 [-i ipaddress] [-e encryption] [-f freq] [-m mode] [-h]
+        Usage: sudo $0 [-i ipaddress] [-e encryption] [-f freq] [-m mode] [-c country] [-o orig_int] [-r ra] [-h]
 
         -i ipaddress    IP address to be used for node
         -e encryption   SAE or NONE

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+
+source ./common.sh
+
+test_case="Mesh connection and Iperf/ping-N hop"
+
+description="Able to connect and ping in N hop topology."
+
+#######################################
+# Init
+# Globals:
+#  result
+#  device_list
+# Arguments:
+#  $1 = ipaddress
+#  $2 = encryption
+#  $3 = frequency
+#######################################
+_init() {
+  _deinit
+  echo "$0, init called" | print_log
+
+	# detect_wifi
+	# multiple wifi options --> can be detected as follows:
+	# manufacturer 0x168c = Qualcomm
+	# devices = 0x0034 0x003c 9462/988x  11s
+	#           0x003e        6174       adhoc
+	#           0x0033        Doodle
+	find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e 0x0033"
+	phyname=${device_list[0]}  # only first pci device is used here
+	wifidev="mesh0"
+  if ! iw phy $phyname interface add $wifidev type mp; then
+    result=$FAIL
+    return
+  fi
+
+  # setup iperf3 server
+  iperf3 -s -p "$iperf3_port"&
+
+  ifconfig "$wifidev" mtu 1560
+  ip link set "$wifidev" up
+  batctl if add "$wifidev"
+  ifconfig bat0 up
+  ifconfig bat0 "$1" netmask 255.255.255.0
+  ifconfig bat0 mtu 1460
+
+  conf_filename="./tmp/wpa_supplicant_11s_$3_$2.conf"
+  log_filename="./logs/wpa_supplicant_11s_$3_$2.log"
+
+  # Create wpa_supplicant.conf here
+  create_wpa_supplicant_config "$conf_filename" "$3" "$2"
+
+  # start wpa_supplicant
+  wpa_supplicant -Dnl80211 -B -i"$wifidev" -C /var/run/wpa_supplicant/ -c "$conf_filename" -f "$log_filename"
+  sleep 5
+  iw dev "$wifidev" set mesh_param mesh_fwding 0
+  iw dev "$wifidev" set mesh_param mesh_ttl 1
+
+  sleep 5
+  wifi_type=$(iw dev mesh0 info | grep type)
+  echo "$wifi_type mode" | print_log
+  case $wifi_type in
+    *"managed"*)
+    result=$FAIL
+    ;;
+    *"mesh"*)
+    result=$PASS
+    ;;
+    *)
+    result=$FAIL
+    return
+    ;;
+  esac
+}
+
+#######################################
+# Test
+# Globals:
+#  result
+# Arguments:
+#  $1 = server ipaddress
+#######################################
+_test() {
+  echo "$0, test called" | print_log
+
+  #1 make test and return with fail if command fails
+  log_dir="logs/"
+
+  # my_command executed and pass logs to logs/-folder
+  wait_ip "$1"
+
+  rm -f ${log_dir}tcp.log
+  exe "iperf3 -f m  -c $1 -i 1 -t 10 -p $iperf3_port --logfile ${log_dir}tcp.log"
+  ret=$?
+  if [ "$ret" != 0 ]; then
+    result=$FAIL
+    echo "Command fails: iperf3" | print_log result
+    return
+  fi
+
+  rm -f ${log_dir}udp.log
+  exe "iperf3 -u -f m -c $1 -i 1 -t 10 -p $iperf3_port -b 500M --logfile ${log_dir}udp.log"
+  ret=$?
+  if [ "$ret" != 0 ]; then
+    result=$FAIL
+    echo "Command fails: iperf3" | print_log result
+    return
+  fi
+
+  ping "$1" -c 10 > ${log_dir}ping.log  # exe can't be used
+  ret=$?
+  if [ "$ret" != 0 ]; then
+    result=$FAIL
+    echo "Command fails: ping" | print_log result
+    return
+  fi
+}
+
+#######################################
+# Result
+# Globals:
+#  result
+# Arguments:
+#######################################
+_result() {
+  echo "$0, result called" | print_log
+
+  sub_result=$PASS
+
+  #1 analyse logs from logs/ - folder
+  tcp_result=$(grep sender -B1 logs/tcp.log)
+  echo -e "# TCP result:\n$tcp_result" | print_log result
+  tcp_avg=$(awk -F " " '($NF=="sender") {print $7}' logs/tcp.log)
+
+  udp_result=$(grep sender -B1 logs/udp.log)
+  echo -e "# UDP result:\n$udp_result" | print_log result
+  udp_avg=$(awk -F " " '($NF=="sender") {print $7}' logs/udp.log)
+
+  ping_result=$(grep rtt -B1 logs/ping.log)
+  echo -e "# ping result:\n$ping_result" | print_log result
+  ping_avg=$(echo "$ping_result" | grep rtt | cut -d '/' -f 5)
+
+	#2 make decision ($PASS or $FAIL)
+
+  # ping limit 4.0milliseconds
+  if (( $(echo "$ping_avg < 3.0" |bc -l) )); then
+    result=$PASS
+  else
+    sub_result=$FAIL
+    echo "FAILED  :in ping test" | print_log result
+  fi
+
+  if (( $(echo "$tcp_avg > 75.0" |bc -l) )); then
+    result=$PASS
+  else
+    sub_result=$FAIL
+    echo "FAILED  :in tcp test" | print_log result
+  fi
+
+  if (( $(echo "$udp_avg > 75.0" |bc -l) )); then
+    result=$PASS
+  else
+    sub_result=$FAIL
+    echo "FAILED  :in udp test" | print_log result
+  fi
+  result=$sub_result
+}
+
+#######################################
+# DeInit
+# Globals:
+#  device_list
+# Arguments:
+#######################################
+_deinit() {
+  echo "$0, deinit called" | print_log
+
+  killall iperf3
+  killall wpa_supplicant
+}
+
+#######################################
+# main
+# Globals:
+#  result
+# Arguments:
+#######################################
+main() {
+
+  help_text=0
+  encryption="NA"
+  frequency=0
+  ipaddress="255.255.255.255"
+  server_ipaddress="255.255.255.255"
+  mode="NA"
+
+  while getopts ":m:s:e:f:i:h" flag
+  do
+    case "${flag}" in
+      e) encryption=${OPTARG};;
+      f) frequency=${OPTARG};;
+      i) ipaddress=${OPTARG};;
+      s) server_ipaddress=${OPTARG};;
+      m) mode=${OPTARG};;
+      h) help_text=1;;
+      *) help_text=1;;
+    esac
+  done
+
+  if [ "$help_text" -eq 1 ] || \
+     [ "$mode" = "NA" ] || \
+     [ "$frequency" -eq 0 ] || \
+     [ "$ipaddress" = "255.255.255.255" ] || \
+     [ "$encryption" = "NA" ]; then
+    echo "
+        Usage: sudo $0 [-i ipaddress] [-e encryption] [-f freq] [-m mode] [-h]
+
+        -i ipaddress    IP address to be used for node
+        -e encryption   SAE or NONE
+        -f frequency    Wi-Fi frequency in MHz
+        -m mode         server or client.
+                        server = test node which provides iperf3
+                        client = test node which runs iperf3/ping tests against server
+        -s address      server address to be used for test connection.
+
+        For Example: sudo $0 -i 192.168.1.2 -e NONE -f 2412 -m server
+
+        -H              Help"
+        return
+  fi
+
+  echo "### Test Case: $test_case" | print_log result
+  echo "### Test Description: $description" | print_log result
+  echo "### Test Settings: | print_log result
+        Node IP address: $ipaddress
+        Iperf3 port: $iperf3_port
+        Encryption: $encryption
+        Wifi Frequency: $frequency
+        mode: $mode" | print_log result
+
+  if  [ "$server_ipaddress" != "255.255.255.255" ]; then
+    echo "        Server IP address: $server_ipaddress" | print_log result
+  fi
+
+  _init "$ipaddress" "$encryption" "$frequency"
+
+  if [ "$result" -eq "$FAIL" ]; then
+    echo "FAILED  _init: $test_case" | print_log result
+    exit 0
+  fi
+
+  if [ "$mode" = "client" ]; then
+    _test "$server_ipaddress"
+
+    if [ "$result" -eq "$FAIL" ]; then
+      echo "FAILED  _test: $test_case" | print_log result
+      exit 0
+    fi
+
+    _result
+
+    if [ "$result" -eq "$FAIL" ]; then
+      echo "FAILED  : $test_case" | print_log result
+      exit 0
+    else
+      echo "PASSED  : $test_case" | print_log result
+      exit 0
+    fi
+  else
+    echo "###" | print_log result
+    echo "###: Please start tests in Client node" | print_log result
+    echo "###" | print_log result
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
test_mesh_connection.sh:
- can be used for NONE/SAE and 2.4GHz/5GHz
- can be used between Mesh nodes, single hop and beyond
- Network topology needs to be handled by tester (no VLAN in use) (separate script coming for chaining with VLAN)

Example:
- DUT responsible for running test:
`sudo ./test_mesh_connection.sh -i 192.168.1.y -e NONE -f 2412 -m client -s 192.168.1.x`

- DUTs respnsible to be part of the network(node):
`sudo ./test_mesh_connection.sh -i 192.168.1.x -e NONE -f 2412 -m server`

```
        Usage: sudo ./test_mesh_connection.sh [-i ipaddress] [-e encryption] [-f freq] [-m mode] [-c country] [-o orig_int] [-r ra] [-h]


        -i ipaddress    IP address to be used for node
        -e encryption   SAE or NONE
        -f frequency    Wi-Fi frequency in MHz
        -c country      2-letter country code e.g. fi, ae, us..
        -m mode         server or client.
                        server = test node which provides iperf3
                        client = test node which runs iperf3/ping tests against server
        -s address      server address to be used for test connection.

        Optional Batman-adv tweaks:
        -o orig_int     OGM (orig) interval tuning in milliseconds (default:1000)
        -r routing      Batman routing algorithm selection (BATMAN_IV, BATMAN_V)
                        (default:BATMAN_IV)

        For Example: sudo ./test_mesh_connection.sh -i 192.168.1.2 -e NONE -f 2412 -m server

        -h              Help
```

Signed-off-by: Mika Joenpera <mika.joenpera@unikie.com>