### PR TITLE
Mesh VLAN support added

### DIFF
--- a/common/tests/functional/check_BSS_list.sh
+++ b/common/tests/functional/check_BSS_list.sh
@@ -6,8 +6,6 @@ test_case="check BSS list in scan results of 2.4/5GHZ MBSS"
 
 description="Scan mesh point in all major channels in 2.4/5GHZ band."
 
-uniq_frequencies=""
-
 #######################################
 # Init
 # Globals:
@@ -26,7 +24,7 @@ _init() {
 	#           0x0033        Doodle
 	find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e"
 	phyname=${device_list[0]}  # only first pci device is used here
-	wifidev="mesh0"
+	wifidev="wlp1s0"
   if ! iw phy $phyname interface add $wifidev type mp; then
     result=$FAIL
     return
@@ -44,26 +42,25 @@ _init() {
 #  wifidev
 #  channel_list
 # Arguments:
+#  $1 = scan duration per channel
+#  $2 = meshid to search if given
 #######################################
 _test() {
   echo "$0, test called" | print_log
 
-  update_channel_list $wifidev
-  echo "Channels: $channel_list" | print_log result
-
 	#1 make test and scan all supported freqs
-  for freq in $channel_list; do
-    iw dev "$wifidev" scan freq "$freq" duration 500 |& tee logs/"$0".log
-    ret=$?
-	  if [ "$ret" != 0 ]; then
-	    result=$FAIL
-	    echo "error: with $freq" | print_log result
-	    return
-	  else
-	    freqs=$(grep -e "freq:" logs/"$0".log | uniq -u >/dev/null)
-	    uniq_frequencies="$uniq_frequencies$freqs"
-	  fi
-	done
+  if [ "$2" = "" ]; then
+    iw dev "$wifidev" scan duration "$1" | grep -e "^BSS" -e "freq:" |& tee logs/"$0".log
+  else
+    iw dev "$wifidev" scan duration "$1" | grep -e "^BSS" -e "$2" -e "freq:" |& tee logs/"$0".log
+  fi
+
+  ret=$?
+  if [ "$ret" != 0 ]; then
+    result=$FAIL
+    echo "error: with scanning frequencies" | print_log result
+    return
+  fi
 }
 
 #######################################
@@ -71,6 +68,8 @@ _test() {
 # Globals:
 #  result
 # Arguments:
+#  $1 = scan duration per channel
+#  $2 = meshid to search if given
 #######################################
 _result() {
   echo "$0, result called" | print_log
@@ -78,9 +77,8 @@ _result() {
   high_band=0
 
   #1 analyse log
-  uniq_freqs=$(grep -e "freq:" logs/"$0".log | uniq)
-  echo -e "unique freqs found: \n $uniq_freqs" | print_log
-
+  uniq_freqs=$(grep -e "freq:" logs/"$0".log | uniq -u)
+  echo -e "unique BSS freqs found: \n $uniq_freqs" | print_log
 	#2 make decision ($PASS or $FAIL)
 	for unit in $uniq_freqs; do
 	  if [ "$unit" != "freq:" ]; then
@@ -91,11 +89,19 @@ _result() {
 	    fi
 	  fi
 	done
-	echo "Found: low_band:$low_band high_band:$high_band" | print_log result
-	if [ "$low_band" -gt 0 ] && [ "$high_band" -gt 0 ]; then
-		result=$PASS
-	else
+	echo "BSS: low_band: $low_band high_band: $high_band" | print_log result
+	if [ "$low_band" -eq 0 ] && [ "$high_band" -eq 0 ]; then
 	  result=$FAIL
+	  echo "Probably a problem in setup low BSS counts." | print_log result
+	fi
+
+  if [ "$2" != "" ]; then
+    meshids=$(grep -e "MESH ID" logs/"$0".log | wc -l)
+    echo -e "MBSS id: \"$2\" count: $meshids" | print_log
+  fi
+	if [ "$meshids" -eq 0 ] && [ "$2" != "" ]; then
+	  result=$FAIL
+	  echo "Cant find searched meshid." | print_log result
 	fi
 }
 
@@ -108,8 +114,8 @@ _result() {
 _deinit() {
   echo "$0, deinit called" | print_log
 
-  killall iperf3
-  killall wpa_supplicant
+  killall iperf3 2>/dev/null
+  killall wpa_supplicant 2>/dev/null
 }
 
 #######################################
@@ -119,6 +125,35 @@ _deinit() {
 # Arguments:
 #######################################
 main() {
+
+  duration="500"
+  meshid=""
+  help_text=0
+
+  while getopts ":m:d:h" flag
+  do
+    case "${flag}" in
+      m) meshid=${OPTARG};;
+      d) duration=${OPTARG};;
+      h) help_text=1;;
+      *) help_text=1;;
+    esac
+  done
+
+  if [ "$help_text" -eq 1 ]; then
+    echo "
+        Usage: sudo $0 [-i ipaddress] [-h]
+
+        -m meshid       meshid name which will be scanned.
+                        If not given, script will scan all possible BSS.
+        -d duration     duration in ms to spend in channel (default:500)
+
+        For Example: sudo $0 -m test_case_run -d 2000
+
+        -h              Help"
+        return
+  fi
+
   echo "### Test Case: $test_case" | print_log result
   echo "### Test Description: $description" | print_log result
 
@@ -129,14 +164,14 @@ main() {
   	exit 0
   fi
 
-  _test
+  _test "$duration" "$meshid"
 
   if [ "$result" -eq "$FAIL" ]; then
   	echo "FAILED  _test: $test_case" | print_log result
   	exit 0
   fi
 
-  _result
+  _result "$duration" "$meshid"
 
   if [ "$result" -eq "$FAIL" ]; then
    	echo "FAILED  : $test_case" | print_log result
@@ -149,4 +184,4 @@ main() {
   _deinit
 }
 
-main
+main "$@"

--- a/common/tests/functional/check_channel_list.sh
+++ b/common/tests/functional/check_channel_list.sh
@@ -27,7 +27,7 @@ _init() {
 	#           0x0033        Doodle
 	find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e"
 	phyname=${device_list[0]}  # only first pci device is used here
-	wifidev="mesh0"
+	wifidev="wlp1s0"
   if ! iw phy $phyname interface add $wifidev type mp; then
     result=$FAIL
     return

--- a/common/tests/functional/check_channel_list.sh
+++ b/common/tests/functional/check_channel_list.sh
@@ -92,8 +92,8 @@ _result() {
 _deinit() {
   echo "$0, deinit called" | print_log
 
-  killall iperf3
-  killall wpa_supplicant
+  killall iperf3 2>/dev/null
+  killall wpa_supplicant 2>/dev/null
 }
 
 #######################################

--- a/common/tests/functional/common/common.sh
+++ b/common/tests/functional/common/common.sh
@@ -192,14 +192,14 @@ wait_ip(){
 
   echo -n "waiting for $1 ..."
   while [ "$server_wait" -eq 1 ]; do
-    if ping -c 1 -w 2 "$1" &> /dev/null; then
+    if ping -c 1 -W 2 "$1" &> /dev/null; then
       echo "$1 is online!"
       server_wait=0
     else
       echo -n "."
       ((timeout=timeout+2))
       if [ "$timeout" -gt 60 ]; then
-        echo "Timeout when waiting $1!"
+        echo "FAILED: Timeout when waiting $1!" | print_log result
         exit 0  # no reason to continue as target IP is not in network
       fi
     fi
@@ -219,5 +219,3 @@ main() {
 }
 
 main
-
-

--- a/common/tests/functional/common/common.sh
+++ b/common/tests/functional/common/common.sh
@@ -181,12 +181,15 @@ exe() {
 
 #######################################
 # Wait IP address until it is online
+#  - will timeout after ~60seconds
 # Globals:
 # Arguments:
 #  $1 = IP address to wait
 #######################################
 wait_ip(){
   server_wait=1
+  timeout=0;
+
   echo -n "waiting for $1 ..."
   while [ "$server_wait" -eq 1 ]; do
     if ping -c 1 -w 2 "$1" &> /dev/null; then
@@ -194,6 +197,11 @@ wait_ip(){
       server_wait=0
     else
       echo -n "."
+      ((timeout=timeout+2))
+      if [ "$timeout" -gt 60 ]; then
+        echo "Timeout when waiting $1!"
+        exit 0  # no reason to continue as target IP is not in network
+      fi
     fi
   done
 }

--- a/common/tests/functional/common/common.sh
+++ b/common/tests/functional/common/common.sh
@@ -11,7 +11,7 @@ trap ctrl_c INT
 # Global constants
 readonly log_file="./functional_tests_debug.log"
 readonly results_file="./functional_tests_results.log"
-readonly NEEDED_EXECUTABLES="wpa_supplicant iw iwlist iperf3 ping uniq grep ip ifconfig batctl bc"
+readonly NEEDED_EXECUTABLES="wpa_supplicant iw iwlist iperf3 ping uniq grep ip ifconfig batctl bc brctl iptables"
 readonly iperf3_port="30001" # constant port number used for iperf3
 readonly PASS=1     # constant for PASS value
 readonly FAIL=0     # constant for FAIL value
@@ -211,7 +211,7 @@ wait_ip(){
 main() {
   echo "Common checks before tests.." | print_log
   for e in $NEEDED_EXECUTABLES; do
-    if [ ! $(which "$e") ]; then
+    if ! command -v "$e"; then
       echo FAIL: missing "$e" | print_log
       exit
     fi

--- a/common/tests/functional/common/common.sh
+++ b/common/tests/functional/common/common.sh
@@ -176,6 +176,7 @@ find_wifi_device()
 #######################################
 exe() {
   echo + "$@"
+  # shellcheck disable=SC2068
   $@ | print_log
 }
 
@@ -211,7 +212,7 @@ wait_ip(){
 main() {
   echo "Common checks before tests.." | print_log
   for e in $NEEDED_EXECUTABLES; do
-    if ! command -v "$e"; then
+    if ! command -v "$e" >/dev/null; then
       echo FAIL: missing "$e" | print_log
       exit
     fi

--- a/common/tests/functional/common/deinit.sh
+++ b/common/tests/functional/common/deinit.sh
@@ -13,7 +13,7 @@ _deinit() {
   ifconfig bat0 down 2>/dev/null
   ifconfig br-lan down 2>/dev/null
   brctl delbr br-lan 2>/dev/null
-  batctl -m bat0 interface destroy 2>/dev/null
+  batctl bat0 interface destroy 2>/dev/null
   killall iperf3 2>/dev/null
   killall wpa_supplicant 2>/dev/null
 }

--- a/common/tests/functional/common/deinit.sh
+++ b/common/tests/functional/common/deinit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#######################################
+# DeInit
+# Globals:
+#  device_list
+# Arguments:
+#######################################
+_deinit() {
+  echo "$0, deinit called" | print_log
+
+  ifconfig "$wifidev" down 2>/dev/null
+  ifconfig bat0 down 2>/dev/null
+  ifconfig br-lan down 2>/dev/null
+  brctl delbr br-lan 2>/dev/null
+  batctl -m bat0 interface destroy 2>/dev/null
+  killall iperf3 2>/dev/null
+  killall wpa_supplicant 2>/dev/null
+}

--- a/common/tests/functional/common/deinit.sh
+++ b/common/tests/functional/common/deinit.sh
@@ -10,10 +10,12 @@ _deinit() {
   echo "$0, deinit called" | print_log
 
   ifconfig "$wifidev" down 2>/dev/null
+  ifconfig "$wifidev-1" down 2>/dev/null
   ifconfig bat0 down 2>/dev/null
   ifconfig br-lan down 2>/dev/null
   brctl delbr br-lan 2>/dev/null
   batctl bat0 interface destroy 2>/dev/null
   killall iperf3 2>/dev/null
   killall wpa_supplicant 2>/dev/null
+  killall hostapd 2>/dev/null
 }

--- a/common/tests/functional/common/init.sh
+++ b/common/tests/functional/common/init.sh
@@ -36,11 +36,14 @@ _init() {
 
   ifconfig "$wifidev" mtu 1560
   ip link set "$wifidev" up
+
+  batctl if add "$wifidev"
+  set_batman_routing_algo "$6"
+  batctl -m bat0 interface destroy  # needed for possible algo selection
   batctl if add "$wifidev"
   set_batman_orig_interval "$5"
-  set_batman_routing_algo "$6"
-
   ifconfig bat0 up
+
   # Create static mac addr for Batman if
   mac_eth0="$(ip -brief link | grep "$wifidev" | awk '{print $3; exit}')"
   mac_bat0="00:00:$(echo "$mac_eth0" | cut -b 7-17)"
@@ -112,9 +115,12 @@ _init_vlan() {
 
   ifconfig "$wifidev" mtu 1560
   ip link set "$wifidev" up
+
+  batctl if add "$wifidev"
+  set_batman_routing_algo "$6"
+  batctl -m bat0 interface destroy  # needed for possible algo selection
   batctl if add "$wifidev"
   set_batman_orig_interval "$5"
-  set_batman_routing_algo "$6"
   ifconfig bat0 up
   ifconfig bat0 mtu 1460
 

--- a/common/tests/functional/common/init.sh
+++ b/common/tests/functional/common/init.sh
@@ -39,7 +39,7 @@ _init() {
 
   batctl if add "$wifidev"
   set_batman_routing_algo "$6"
-  batctl -m bat0 interface destroy  # needed for possible algo selection
+  batctl bat0 interface destroy  # needed for possible algo selection
   batctl if add "$wifidev"
   set_batman_orig_interval "$5"
   ifconfig bat0 up
@@ -118,7 +118,7 @@ _init_vlan() {
 
   batctl if add "$wifidev"
   set_batman_routing_algo "$6"
-  batctl -m bat0 interface destroy  # needed for possible algo selection
+  batctl bat0 interface destroy  # needed for possible algo selection
   batctl if add "$wifidev"
   set_batman_orig_interval "$5"
   ifconfig bat0 up

--- a/common/tests/functional/common/init.sh
+++ b/common/tests/functional/common/init.sh
@@ -51,6 +51,9 @@ _init() {
   ifconfig bat0 "$1" netmask 255.255.255.0
   ifconfig bat0 mtu 1460
 
+  # Default forward policy config
+  iptables -P FORWARD ACCEPT
+
   conf_filename="./tmp/wpa_supplicant_11s_$3_$2.conf"
   log_filename="./logs/wpa_supplicant_11s_$3_$2.log"
 
@@ -133,12 +136,6 @@ _init_vlan() {
   # Create wpa_supplicant.conf here
   create_wpa_supplicant_config "$conf_filename" "$3" "$2" "$4"
 
-  # start wpa_supplicant
-  wpa_supplicant -Dnl80211 -B -i"$wifidev" -C /var/run/wpa_supplicant/ -c "$conf_filename" -f "$log_filename"
-  sleep 5
-  iw dev "$wifidev" set mesh_param mesh_fwding 0
-  iw dev "$wifidev" set mesh_param mesh_ttl 1
-
   # Create static mac addr for Batman if
   mac_eth0="$(ip -brief link | grep "$wifidev" | awk '{print $3; exit}')"
   mac_bat0="00:00:$(echo "$mac_eth0" | cut -b 7-17)"
@@ -165,6 +162,120 @@ _init_vlan() {
   # Disable batman bridge loop avoidance
   batctl meshif bat0 bridge_loop_avoidance 0
   echo "Batman chain bat0.$vbat bat0.$(("$vbat"+1)) done."
+
+ # start wpa_supplicant
+  wpa_supplicant -Dnl80211 -B -i"$wifidev" -C /var/run/wpa_supplicant/ -c "$conf_filename" -f "$log_filename"
+  sleep 5
+  iw dev "$wifidev" set mesh_param mesh_fwding 0
+  iw dev "$wifidev" set mesh_param mesh_ttl 1
+
+  sleep 5
+  wifi_type=$(iw dev "$wifidev" info | grep type)
+  echo "$wifi_type mode" | print_log
+  case $wifi_type in
+    *"managed"*)
+    result=$FAIL
+    ;;
+    *"mesh"*)
+    result=$PASS
+    ;;
+    *)
+    result=$FAIL
+    return
+    ;;
+  esac
+}
+
+#######################################
+# Init MESH_AP
+# Globals:
+#  result
+#  device_list
+# Arguments:
+#  $1 = ipaddress
+#  $2 = encryption
+#  $3 = frequency
+#  $4 = country
+#  $5 = Batman orig_interval
+#  $6 = Batman routing algo
+#######################################
+_init_mesh_ap() {
+  _deinit
+  echo "$0, init called" | print_log
+  # detect_wifi
+  # multiple wifi options --> can be detected as follows:
+  # manufacturer 0x168c = Qualcomm
+  # devices = 0x0034 0x003c 9462/988x  11s
+  #           0x003e        6174       adhoc
+  #           0x0033        Doodle
+  find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e 0x0033"
+  phyname=${device_list[0]}  # only first pci device is used here
+  wifidev="wlp1s0"
+  if ! iw phy $phyname interface add $wifidev type mp; then
+    result=$FAIL
+    return
+  fi
+
+  # setup iperf3 server
+  iperf3 -s -D -p "$iperf3_port" --forceflush
+
+  ifconfig "$wifidev" mtu 1560
+  ip link set "$wifidev" up
+
+  batctl if add "$wifidev"
+  set_batman_routing_algo "$6"
+  batctl bat0 interface destroy  # needed for possible algo selection
+  batctl if add "$wifidev"
+  set_batman_orig_interval "$5"
+  ifconfig bat0 up
+  ifconfig bat0 mtu 1460
+
+  # Default forward policy config
+  iptables -P FORWARD ACCEPT
+
+  conf_filename="./tmp/wpa_supplicant_11s_$3_$2.conf"
+  log_filename="./logs/wpa_supplicant_11s_$3_$2.log"
+
+  # Create wpa_supplicant.conf here
+  create_wpa_supplicant_config "$conf_filename" "$3" "$2" "$4"
+
+  # Create static mac addr for Batman if
+  mac_eth0="$(ip -brief link | grep "$wifidev" | awk '{print $3; exit}')"
+  mac_bat0="00:00:$(echo "$mac_eth0" | cut -b 7-17)"
+  ifconfig bat0 hw ether "$mac_bat0"
+
+  # Create bridge br-lan
+  brctl addbr br-lan
+
+  # start wpa_supplicant
+  wpa_supplicant -Dnl80211 -B -i"$wifidev" -C /var/run/wpa_supplicant/ -c "$conf_filename" -f "$log_filename"
+  sleep 5
+  iw dev "$wifidev" set mesh_param mesh_fwding 0
+  iw dev "$wifidev" set mesh_param mesh_ttl 1
+
+  # AP setup
+  wifimac="$(ip -brief link | grep "$wifidev" | awk '{print $3; exit}')"
+  ssid="lite#$(echo "$wifimac" | cut -b 13-14,16-17)"
+
+  apif="$wifidev-1"
+  iw dev "$wifidev" interface add "$apif" type managed addr "00:01:$(echo "$wifimac" | cut -b 7-17)"
+
+  conf_filename="./tmp/hostapd_$3_$2.conf"
+  log_filename="./logs/hostapd_$3_$2.log"
+
+  # Create wpa_supplicant.conf here
+  create_hostapd_config "$conf_filename" "$3" "$2" "$4" "$apif" "$ssid"
+
+  # Start AP
+  /usr/sbin/hostapd -B "$conf_filename" -f "$log_filename"
+
+  # Bridge AP and Mesh
+  brctl addif br-lan bat0 "$apif"
+  ifconfig br-lan "$1" netmask 255.255.255.0
+  ifconfig br-lan up
+  echo
+  ifconfig br-lan
+  echo "Mesh Point + AP done."
 
   sleep 5
   wifi_type=$(iw dev "$wifidev" info | grep type)

--- a/common/tests/functional/common/init.sh
+++ b/common/tests/functional/common/init.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+#######################################
+# Init
+# Globals:
+#  result
+#  device_list
+# Arguments:
+#  $1 = ipaddress
+#  $2 = encryption
+#  $3 = frequency
+#  $4 = country
+#  $5 = Batman orig_interval
+#  $6 = Batman routing algo
+#######################################
+_init() {
+  _deinit
+  echo "$0, init called" | print_log
+
+  # detect_wifi
+  # multiple wifi options --> can be detected as follows:
+  # manufacturer 0x168c = Qualcomm
+  # devices = 0x0034 0x003c 9462/988x  11s
+  #           0x003e        6174       adhoc
+  #           0x0033        Doodle
+  find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e 0x0033"
+  phyname=${device_list[0]}  # only first pci device is used here TODO
+  wifidev="wlp1s0"
+  if ! iw phy $phyname interface add $wifidev type mp; then
+    result=$FAIL
+    return
+  fi
+
+  # setup iperf3 server
+  iperf3 -s -D -p "$iperf3_port" --forceflush
+
+  ifconfig "$wifidev" mtu 1560
+  ip link set "$wifidev" up
+  batctl if add "$wifidev"
+  set_batman_orig_interval "$5"
+  set_batman_routing_algo "$6"
+
+  ifconfig bat0 up
+  # Create static mac addr for Batman if
+  mac_eth0="$(ip -brief link | grep "$wifidev" | awk '{print $3; exit}')"
+  mac_bat0="00:00:$(echo "$mac_eth0" | cut -b 7-17)"
+  ifconfig bat0 hw ether "$mac_bat0"
+  ifconfig bat0 "$1" netmask 255.255.255.0
+  ifconfig bat0 mtu 1460
+
+  conf_filename="./tmp/wpa_supplicant_11s_$3_$2.conf"
+  log_filename="./logs/wpa_supplicant_11s_$3_$2.log"
+
+  # Create wpa_supplicant.conf here
+  create_wpa_supplicant_config "$conf_filename" "$3" "$2" "$4"
+
+  # start wpa_supplicant
+  wpa_supplicant -Dnl80211 -B -i"$wifidev" -C /var/run/wpa_supplicant/ -c "$conf_filename" -f "$log_filename"
+  sleep 5
+  iw dev "$wifidev" set mesh_param mesh_fwding 0
+  iw dev "$wifidev" set mesh_param mesh_ttl 1
+
+  sleep 5
+  wifi_type=$(iw dev "$wifidev" info | grep type)
+  echo "$wifi_type mode" | print_log
+  case $wifi_type in
+    *"managed"*)
+    result=$FAIL
+    ;;
+    *"mesh"*)
+    result=$PASS
+    ;;
+    *)
+    result=$FAIL
+    return
+    ;;
+  esac
+}
+
+#######################################
+# Init VLAN
+# Globals:
+#  result
+#  device_list
+# Arguments:
+#  $1 = ipaddress
+#  $2 = encryption
+#  $3 = frequency
+#  $4 = country
+#  $5 = Batman orig_interval
+#  $6 = Batman routing algo
+#######################################
+_init_vlan() {
+  _deinit
+  echo "$0, init called" | print_log
+  # detect_wifi
+  # multiple wifi options --> can be detected as follows:
+  # manufacturer 0x168c = Qualcomm
+  # devices = 0x0034 0x003c 9462/988x  11s
+  #           0x003e        6174       adhoc
+  #           0x0033        Doodle
+  find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e 0x0033"
+  phyname=${device_list[0]}  # only first pci device is used here
+  wifidev="wlp1s0"
+  if ! iw phy $phyname interface add $wifidev type mp; then
+    result=$FAIL
+    return
+  fi
+
+  # setup iperf3 server
+  iperf3 -s -D -p "$iperf3_port" --forceflush
+
+  ifconfig "$wifidev" mtu 1560
+  ip link set "$wifidev" up
+  batctl if add "$wifidev"
+  set_batman_orig_interval "$5"
+  set_batman_routing_algo "$6"
+  ifconfig bat0 up
+  ifconfig bat0 mtu 1460
+
+  # Default forward policy config
+  iptables -P FORWARD ACCEPT
+
+  conf_filename="./tmp/wpa_supplicant_11s_$3_$2.conf"
+  log_filename="./logs/wpa_supplicant_11s_$3_$2.log"
+
+  # Create wpa_supplicant.conf here
+  create_wpa_supplicant_config "$conf_filename" "$3" "$2" "$4"
+
+  # start wpa_supplicant
+  wpa_supplicant -Dnl80211 -B -i"$wifidev" -C /var/run/wpa_supplicant/ -c "$conf_filename" -f "$log_filename"
+  sleep 5
+  iw dev "$wifidev" set mesh_param mesh_fwding 0
+  iw dev "$wifidev" set mesh_param mesh_ttl 1
+
+  # Create static mac addr for Batman if
+  mac_eth0="$(ip -brief link | grep "$wifidev" | awk '{print $3; exit}')"
+  mac_bat0="00:00:$(echo "$mac_eth0" | cut -b 7-17)"
+  ifconfig bat0 hw ether "$mac_bat0"
+
+  # Create bridge br-lan
+  brctl addbr br-lan
+
+  # Batman Mesh virtual network chain
+  vbat="$(echo "$1" | rev | cut -d "." -f1 | rev)"
+  ip link add link bat0 name bat0."$vbat" type vlan id "$vbat"
+  ip link add link bat0 name bat0.$(("$vbat"+1)) type vlan id $(("$vbat"+1))
+
+  # Virtual interface up
+  ifconfig bat0."$vbat" up
+  ifconfig bat0.$(("$vbat"+1)) up
+  brctl addif br-lan bat0."$vbat"
+  brctl addif br-lan bat0.$(("$vbat"+1))
+  ifconfig br-lan "$1" netmask 255.255.255.0
+  ifconfig br-lan up
+  echo
+  ifconfig br-lan
+
+  # Disable batman bridge loop avoidance
+  batctl meshif bat0 bridge_loop_avoidance 0
+  echo "Batman chain bat0.$vbat bat0.$(("$vbat"+1)) done."
+
+  sleep 5
+  wifi_type=$(iw dev "$wifidev" info | grep type)
+  echo "$wifi_type mode" | print_log
+  case $wifi_type in
+    *"managed"*)
+    result=$FAIL
+    ;;
+    *"mesh"*)
+    result=$PASS
+    ;;
+    *)
+    result=$FAIL
+    return
+    ;;
+  esac
+}

--- a/common/tests/functional/template/template.sh
+++ b/common/tests/functional/template/template.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-source ./common/common.sh
+source ./common/common.sh   # common tools
+# source ./common/init.sh     # network init
+# source ./common/deinit.sh   # network de-init
 
 test_case="test case name from excel"
 
@@ -106,7 +108,7 @@ main() {
 
         For Example: sudo $0 -i 192.168.1.2
 
-        -H              Help"
+        -h              Help"
         return
   fi
 

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -89,7 +89,7 @@ _result() {
   ping_avg=$(echo "$ping_result" | grep -e rtt -e round-trip | cut -d ' ' -f 4 | cut -d '/' -f 2)
 
   # compare requested CC to set CC
-  iw_reg_country=$(iw phy phy3 reg get | grep global -A1 | awk 'END{print $2}')
+  iw_reg_country=$(iw phy $phyname reg get | grep global -A1 | awk 'END{print $2}')
   iw_reg_country=${iw_reg_country::-1}
   echo -e "# Regulatory check:\nRequested=${1^^} and iw reg get=$iw_reg_country" | print_log result
   if [ "$iw_reg_country" != "${1^^}" ]; then
@@ -230,16 +230,20 @@ main() {
 
     _result "$country"
 
-    mesh_hop=$(("${server_ipaddress##*.}"-"${ipaddress##*.}"))
+    if [ "$net_setup" = "mesh_vlan" ]; then
+      mesh_hop=$(("${server_ipaddress##*.}"-"${ipaddress##*.}"))
+      echo "Hop count: ${mesh_hop#-}" | print_log result
+    fi
+
     if [ "$result" -eq "$FAIL" ]; then
-      echo "FAILED  : $test_case: ${mesh_hop#-}" | print_log result
+      echo "FAILED  : $test_case" | print_log result
       echo "        : " | print_log result
       echo "HOX!!   : Throughput/ping depends on distance and hop count. Even
         : test case is set as Failed, more analysis needed for the reason. e.g
         : if multihops were tested this can be a PASS." | print_log result
       exit 0
     else
-      echo "PASSED  : $test_case: ${mesh_hop#-}" | print_log result
+      echo "PASSED  : $test_case" | print_log result
       exit 0
     fi
   else

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -156,7 +156,12 @@ main() {
     esac
   done
 
-  if [ "$help_text" -eq 1 ] || \
+
+  if [ "$net_setup" = "skip" ] && \
+     [ "$ipaddress" != "255.255.255.255" ]; then
+    frequency="skip"
+    encryption="skip"
+  elif [ "$help_text" -eq 1 ] || \
      [ "$mode" = "NA" ] || \
      [ "$frequency" -eq 0 ] || \
      [ "$ipaddress" = "255.255.255.255" ] || \

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -1,82 +1,12 @@
 #!/bin/bash
 
-source ./common/common.sh
+source ./common/common.sh   # common tools
+source ./common/init.sh     # network init
+source ./common/deinit.sh   # network de-init
 
 test_case="Mesh connection and Iperf/ping-N hop"
 
 description="Able to connect and ping in N hop topology."
-
-#######################################
-# Init
-# Globals:
-#  result
-#  device_list
-# Arguments:
-#  $1 = ipaddress
-#  $2 = encryption
-#  $3 = frequency
-#  $4 = country
-#  $5 = Batman orig_interval
-#  $6 = Batman routing algo
-#######################################
-_init() {
-  _deinit
-  echo "$0, init called" | print_log
-
-	# detect_wifi
-	# multiple wifi options --> can be detected as follows:
-	# manufacturer 0x168c = Qualcomm
-	# devices = 0x0034 0x003c 9462/988x  11s
-	#           0x003e        6174       adhoc
-	#           0x0033        Doodle
-  find_wifi_device "pci" 0x168c "0x0034 0x003c 0x003e 0x0033"
-  phyname=${device_list[0]}  # only first pci device is used here
-  wifidev="mesh0"
-  if ! iw phy $phyname interface add $wifidev type mp; then
-    result=$FAIL
-    return
-  fi
-
-  # setup iperf3 server
-  iperf3 -s -p "$iperf3_port"&
-
-  ifconfig "$wifidev" mtu 1560
-  ip link set "$wifidev" up
-  batctl if add "$wifidev"
-  set_batman_orig_interval "$5"
-  set_batman_routing_algo "$6"
-  ifconfig bat0 up
-  ifconfig bat0 "$1" netmask 255.255.255.0
-  ifconfig bat0 mtu 1460
-
-  conf_filename="./tmp/wpa_supplicant_11s_$3_$2.conf"
-  log_filename="./logs/wpa_supplicant_11s_$3_$2.log"
-
-  # Create wpa_supplicant.conf here
-  create_wpa_supplicant_config "$conf_filename" "$3" "$2" "$4"
-
-  # start wpa_supplicant
-  wpa_supplicant -Dnl80211 -B -i"$wifidev" -C /var/run/wpa_supplicant/ -c "$conf_filename" -f "$log_filename"
-  sleep 5
-  iw dev "$wifidev" set mesh_param mesh_fwding 0
-  iw dev "$wifidev" set mesh_param mesh_ttl 1
-
-  sleep 5
-  wifi_type=$(iw dev mesh0 info | grep type)
-  echo "$wifi_type mode" | print_log
-  case $wifi_type in
-    *"managed"*)
-    result=$FAIL
-    ;;
-    *"mesh"*)
-    result=$PASS
-    ;;
-    *)
-    result=$FAIL
-    return
-    ;;
-  esac
-}
 
 #######################################
 # Test
@@ -126,13 +56,14 @@ _test() {
 # Globals:
 #  result
 # Arguments:
+#  $1 = requested country code
 #######################################
 _result() {
   echo "$0, result called" | print_log
 
-  sub_result=$PASS
-
   #1 analyse logs from logs/ - folder
+
+  # analyse TCP log file
   if ! grep "connection refused" logs/tcp.log; then
     tcp_result=$(grep sender -B1 logs/tcp.log)
     echo -e "# TCP result:\n$tcp_result" | print_log result
@@ -142,6 +73,7 @@ _result() {
     tcp_avg="0"
   fi
 
+  # analyse UDP log file
   if ! grep "connection refused" logs/udp.log; then
     udp_result=$(grep sender -B1 logs/udp.log)
     echo -e "# UDP result:\n$udp_result" | print_log result
@@ -151,47 +83,36 @@ _result() {
     udp_avg="0"
   fi
 
+  # analyse ping results
   ping_result=$(grep -e rtt -e round-trip -B1 logs/ping.log)
   echo -e "# ping result:\n$ping_result" | print_log result
   ping_avg=$(echo "$ping_result" | grep -e rtt -e round-trip | cut -d ' ' -f 4 | cut -d '/' -f 2)
 
-	#2 make decision ($PASS or $FAIL)
+  # compare requested CC to set CC
+  iw_reg_country=$(iw phy phy3 reg get | grep global -A1 | awk 'END{print $2}')
+  iw_reg_country=${iw_reg_country::-1}
+  echo -e "# Regulatory check:\nRequested=${1^^} and iw reg get=$iw_reg_country" | print_log result
+  if [ "$iw_reg_country" != "${1^^}" ]; then
+    result=$FAIL
+    echo "FAILED  : Regulatory setting failed" | print_log result
+  fi
 
+	#2 make decision ($PASS or $FAIL)
   # ping limit 3.0milliseconds
-  if (( $(echo "$ping_avg < 3.0" |bc -l) )); then
-    result=$PASS
-  else
-    sub_result=$FAIL
+  if (( $(echo "$ping_avg > 3.0" |bc -l) )); then
+    result=$FAIL
     echo "FAILED  : in ping test" | print_log result
   fi
 
-  if (( $(echo "$tcp_avg > 75.0" |bc -l) )); then
-    result=$PASS
-  else
-    sub_result=$FAIL
+  if (( $(echo "$tcp_avg < 75.0" |bc -l) )); then
+    result=$FAIL
     echo "FAILED  : in tcp test" | print_log result
   fi
 
-  if (( $(echo "$udp_avg > 75.0" |bc -l) )); then
-    result=$PASS
-  else
-    sub_result=$FAIL
+  if (( $(echo "$udp_avg < 75.0" |bc -l) )); then
+    result=$FAIL
     echo "FAILED  : in udp test" | print_log result
   fi
-  result=$sub_result
-}
-
-#######################################
-# DeInit
-# Globals:
-#  device_list
-# Arguments:
-#######################################
-_deinit() {
-  echo "$0, deinit called" | print_log
-
-  killall iperf3
-  killall wpa_supplicant
 }
 
 #######################################
@@ -211,8 +132,9 @@ main() {
   ipaddress="255.255.255.255"
   server_ipaddress="255.255.255.255"
   mode="NA"
+  net_setup="mesh"
 
-  while getopts ":m:s:r:o:c:e:f:i:h" flag
+  while getopts ":m:s:r:n:o:c:e:f:i:h" flag
   do
     case "${flag}" in
       e) encryption=${OPTARG};;
@@ -223,6 +145,7 @@ main() {
       m) mode=${OPTARG};;
       r) routing_algo=${OPTARG};;
       o) orig_interval=${OPTARG};;
+      n) net_setup=${OPTARG};;
       h) help_text=1;;
       *) help_text=1;;
     esac
@@ -245,6 +168,11 @@ main() {
                         client = test node which runs iperf3/ping tests against server
         -s address      server address to be used for test connection.
 
+        -n net_setup    mesh      = normal Batman mesh node (default)
+                        mesh+ap   = Batman mesh node + Access-point in same channel (not implemented)
+                        mesh_vlan = Batman mesh node using VLAN (easy chain setup)
+                        skip      = skip network setup and just execute tests
+
         Optional Batman-adv tweaks:
         -o orig_int     OGM (orig) interval tuning in milliseconds (default:1000)
         -r routing      Batman routing algorithm selection (BATMAN_IV, BATMAN_V)
@@ -258,13 +186,14 @@ main() {
 
   echo "### Test Case: $test_case" | print_log result
   echo "### Test Description: $description" | print_log result
-  echo "### Test Settings: | print_log result
+  echo "### Test Settings:
         Node IP address:          $ipaddress
         Iperf3 port:              $iperf3_port
         Encryption:               $encryption
         Wifi Frequency:           $frequency
         Wifi Country Regulatory:  $country
         mode:                     $mode
+        Network Setup:            $net_setup
         Batman orig_interval:     $orig_interval
         Batman routing algorithm: $routing_algo" | print_log result
 
@@ -272,7 +201,19 @@ main() {
     echo "        Server IP address:        $server_ipaddress" | print_log result
   fi
 
-  _init "$ipaddress" "$encryption" "$frequency" "$country" "$orig_interval" "$routing_algo"
+  case $net_setup in
+    "mesh")
+    _init "$ipaddress" "$encryption" "$frequency" "$country" "$orig_interval" "$routing_algo"
+    ;;
+    "mesh_vlan")
+    _init_vlan "$ipaddress" "$encryption" "$frequency" "$country" "$orig_interval" "$routing_algo"
+    ;;
+    "skip")
+    ;;
+    *)
+    echo "Network Setup option: $net_setup not implemented" | print_log
+    ;;
+  esac
 
   if [ "$result" -eq "$FAIL" ]; then
     echo "FAILED  _init: $test_case" | print_log result
@@ -287,17 +228,18 @@ main() {
       exit 0
     fi
 
-    _result
+    _result "$country"
 
+    mesh_hop=$(("${server_ipaddress##*.}"-"${ipaddress##*.}"))
     if [ "$result" -eq "$FAIL" ]; then
-      echo "FAILED  : $test_case" | print_log result
+      echo "FAILED  : $test_case: ${mesh_hop#-}" | print_log result
       echo "        : " | print_log result
       echo "HOX!!   : Throughput/ping depends on distance and hop count. Even
         : test case is set as Failed, more analysis needed for the reason. e.g
         : if multihops were tested this can be a PASS." | print_log result
       exit 0
     else
-      echo "PASSED  : $test_case" | print_log result
+      echo "PASSED  : $test_case: ${mesh_hop#-}" | print_log result
       exit 0
     fi
   else

--- a/common/tests/functional/test_mesh_connection.sh
+++ b/common/tests/functional/test_mesh_connection.sh
@@ -179,7 +179,7 @@ main() {
         -s address      server address to be used for test connection.
 
         -n net_setup    mesh      = normal Batman mesh node (default)
-                        mesh+ap   = Batman mesh node + Access-point in same channel (not implemented)
+                        mesh_ap   = Batman mesh node + Access-point in same channel (not implemented)
                         mesh_vlan = Batman mesh node using VLAN (easy chain setup)
                         skip      = skip network setup and just execute tests
 
@@ -217,6 +217,9 @@ main() {
     ;;
     "mesh_vlan")
     _init_vlan "$ipaddress" "$encryption" "$frequency" "$country" "$orig_interval" "$routing_algo"
+    ;;
+    "mesh_ap")
+    _init_mesh_ap "$ipaddress" "$encryption" "$frequency" "$country" "$orig_interval" "$routing_algo"
     ;;
     "skip") # some other service is taking care of network setup
     killall iperf3 2>/dev/null


### PR DESCRIPTION
Now it is possible to build mesh node chains with VLAN when
testing multihops.

_init() and _deinit() functions moved to common/*init.sh.

Signed-off-by: Mika Joenpera <mika.joenpera@unikie.com>