### PR TITLE
Use fog-ros-baseimage in Docker image

### DIFF
--- a/modules/mesh_com/Dockerfile
+++ b/modules/mesh_com/Dockerfile
@@ -30,7 +30,6 @@ FROM ghcr.io/tiiuae/fog-ros-baseimage:DP-2016-dockerfiles-pkcs-11-updates
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     wpasupplicant=2.9.0-20-6~git20210701.43d8971 \
     wifi-firmware \
-    ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
     iw \
     batctl \
     alfred \

--- a/modules/mesh_com/Dockerfile
+++ b/modules/mesh_com/Dockerfile
@@ -1,5 +1,4 @@
-# mesh_com BUILDER
-FROM ros:galactic-ros-base as builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage:builder-DP-2016-dockerfiles-pkcs-11-updates AS builder
 
 # Install build dependencies
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
@@ -9,30 +8,29 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     dh-make \
     dh-python \
     python3-pytest \
-    ros-galactic-ament-flake8 \
-    ros-galactic-ament-pep257 \
+    ros-${ROS_DISTRO}-ament-flake8 \
+    ros-${ROS_DISTRO}-ament-pep257 \
     && rm -rf /var/lib/apt/lists/*
 
 # Build mesh_com
-WORKDIR /mesh_com/src
-ADD . /mesh_com/src
-RUN modules/mesh_com/package.sh 0 focal
+COPY . /main_ws/src/
 
+# this:
+# 1) builds the application
+# 2) packages the application as .deb in /main_ws/
+RUN /packaging/build.sh
 
+#  ▲               runtime ──┐
+#  └── build                 ▼
 
-# tii-mesh-com image
-FROM ros:galactic-ros-core
-
-ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-
-RUN echo "deb [trusted=yes] https://ssrc.jfrog.io/artifactory/ssrc-debian-public-remote focal fog-sw" >> /etc/apt/sources.list
+FROM ghcr.io/tiiuae/fog-ros-baseimage:DP-2016-dockerfiles-pkcs-11-updates
 
 # wpasupplicant pinned as to receive SSRC version (and not Ubuntu) of it which has some mesh-related customizations:
 # https://github.com/tiiuae/wpa
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     wpasupplicant=2.9.0-20-6~git20210701.43d8971 \
     wifi-firmware \
-    ros-galactic-rmw-fastrtps-cpp \
+    ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
     iw \
     batctl \
     alfred \
@@ -40,13 +38,10 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PACKAGE_NAME mesh_com
-ENTRYPOINT ["/mesh_com/entrypoint.sh"]
+ENTRYPOINT [ "/entrypoint.sh" ]
 
-COPY --from=builder /mesh_com/src/modules/mesh_com/entrypoint.sh /mesh_com/entrypoint.sh
+COPY modules/mesh_com/entrypoint.sh /entrypoint.sh
 
-# Install mesh_com
-WORKDIR /mesh_com
-COPY --from=builder /mesh_com/src/modules/*.deb .
-RUN dpkg -i *.deb && rm -f *.deb
+COPY --from=builder /main_ws/src/modules/ros-*-mesh-com_*_amd64.deb /mesh-com.deb
 
+RUN dpkg -i /mesh-com.deb && rm /mesh-com.deb


### PR DESCRIPTION
FOG mission computer Docker containers are using the same base image. This component needs to use the same base image.
Benefits:
- Updates are synchronized
- Less resources used by containers (hard disk, bandwidth)
- Faster updates