### PR TITLE
Add support for Doodle Labs Qualcomm Atheros: QCA9590-BR4B wireless card

### DIFF
--- a/common/scripts/mesh-ibss.sh
+++ b/common/scripts/mesh-ibss.sh
@@ -65,9 +65,10 @@ if [[ -z "${10}" ]]; then
   rfkill unblock all
   # multiple wifi options --> can be detected as follows:
   # manufacturer 0x168c = Qualcomm
-  # devices = 0x0034 0x003c 9462/988x
-  #           0x003e        6174
-  find_mesh_wifi_device 0x168c "0x003e 0x0034 0x003c"
+  # devices = 0x0034 0x003c 9462/988x  11s
+  #           0x003e        6174       adhoc
+  #           0x0033        9590       doodle
+  find_mesh_wifi_device 0x168c "0x0034 0x003c 0x003e 0x0033"
 
   if [ "$retval_phy" != "" ]; then
       phyname=$retval_phy


### PR DESCRIPTION
Add support for Doodle Labs Qualcomm Atheros: QCA9590-BR4B wireless card