### PR TITLE
2 mesh networks (GS and Edge) support added

### DIFF
--- a/common/scripts/mesh-ibss.sh
+++ b/common/scripts/mesh-ibss.sh
@@ -22,7 +22,7 @@ function help
     echo
     echo "example:"
     echo "sudo ./mesh-ibss.sh mesh 192.168.1.2 255.255.255.0 00:11:22:33:44:55 1234567890 mymesh 5220 30 fi wlan1 phy1"
-    echo "sudo mesh.sh ap"
+    echo "sudo ./mesh-ibss.sh ap"
     exit
 }
 

--- a/modules/mesh_com/README.md
+++ b/modules/mesh_com/README.md
@@ -1,8 +1,16 @@
 # mesh_com
 
-mesh_com ROS node subsriber listening topic "mesh_parameters". 
+mesh_com ROS node subsriber listening topic "mesh_parameters".
 Supports following configuration JSON as String format:
 
+1st level
+```json
+{
+ "edge": {2nd level},                 "mesh network class. edge=edge mesh network, gs=groundstation mesh network"
+}
+```
+
+2nd level
 ```json
 {
  "api_version": 1,                 "interface version for future purposes"
@@ -23,4 +31,31 @@ Supports following configuration JSON as String format:
  "mode": "mesh"                    "mesh=mesh network, ap=debug hotspot"
 }
 ```
-
+## Google IoT config block example
+```python
+initial-wifi:
+    edge:
+        api_version: 2
+        ssid: default-edge
+        key: "foobar"
+        enc: wep
+        ap_mac: "00:11:22:33:44:55"
+        country: cn
+        frequency: "5180"
+        ip: 192.168.1.10
+        subnet: 255.255.255.0
+        tx_power: "30"
+        mode: mesh
+    gs:
+        api_version: 2
+        ssid: default-gs
+        key: "foobar"
+        enc: wep
+        ap_mac: "00:11:22:33:44:55"
+        country: cn
+        frequency: "5745"
+        ip: 192.168.32.10
+        subnet: 255.255.255.0
+        tx_power: "30"
+        mode: mesh
+```

--- a/modules/mesh_com/entrypoint.sh
+++ b/modules/mesh_com/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-. /enclave/drone_device_id
+# . /enclave/drone_device_id
 
-export DRONE_DEVICE_ID
+# export DRONE_DEVICE_ID
 
 source /opt/ros/galactic/setup.bash
 
@@ -13,10 +13,34 @@ export PYTHONPATH=/opt/ros/galactic/lib/python3.8/site-packages
 if [ "$1" == "init" ]; then
 
     echo "Start mesh executor"
-    # Start mesh executor
-    /opt/ros/galactic/share/bin/mesh-ibss.sh ap
-    /opt/ros/galactic/lib/mesh_com/mesh_executor
+    # Start mesh executor 
+    #                     1      2    3      4        5     6       7      8         9         10          11        12             13         14
+    # Usage: mesh-11s.sh <mode> <ip> <mask> <AP MAC> <key> <essid> <freq> <txpower> <country> <interface> <phyname> <routing_algo> <mtu_size> <log_dir>
+    # 
+    # Number:      Parameter:                    Environment Variable:
+    # 1            <mode>                        $DEFAULT_MESH_MODE
+    # 2            <ip>                          $DEFAULT_MESH_IP
+    # 3            <mask>                        $DEFAULT_MESH_MASK
+    # 4            <AP MAC>                      $DEFAULT_MESH_MAC
+    # 5            <WEP key>                     $DEFAULT_MESH_KEY
+    # 6            <essid>                       $DEFAULT_MESH_ESSID
+    # 7            <freq>                        $DEFAULT_MESH_FREQ
+    # 8	           <txpower>                     $DEFAULT_MESH_TX
+    # 9	           <country>                     $DEFAULT_MESH_COUNTRY
+    # 10           <interface> - optional        $DEFAULT_MESH_IFACE
+    # 11           <phyname> - optional          $DEFAULT_MESH_PHY
+    # 12           <routing_algo> - optional     $DEFAULT_MESH_RTALG
+    # 13           <mtu_dir>   - optional        $DEFAULT_MESH_MTU
+    # 14           <log_dir>   - optional        $DEFAULT_MESH_LOG
+    #
+    # example:
+    #     mesh-11s.sh mesh 192.168.1.2 255.255.255.0 00:11:22:33:44:55 1234567890 mymesh 5220 30 fi wlan1 phy1
+    #     mesh-11s.sh ap
 
+    #starting Default mesh
+    /opt/ros/galactic/share/bin/mesh-11s.sh $DEFAULT_MESH_MODE $DEFAULT_MESH_IP $DEFAULT_MESH_MASK $DEFAULT_MESH_MAC $DEFAULT_MESH_KEY $DEFAULT_MESH_ESSID $DEFAULT_MESH_FREQ $DEFAULT_MESH_TX $DEFAULT_MESH_COUNTRY
+    /opt/ros/galactic/lib/mesh_com/mesh_executor
+    # flawed injection: sleep 86400
 else
     echo "Start mesh pub&sub"
 


### PR DESCRIPTION
2 mesh networks (GS and Edge) support added. 
Default mesh enabled. 
Settings are based on manifest-defined environment variables.

```
### Google IoT 2-mesh config example
initial-wifi:
    edge:
        api_version: 2
        ssid: default-edge
        key: "foobar"
        enc: wep
        ap_mac: "00:11:22:33:44:55"
        country: cn
        frequency: "5180"
        ip: 192.168.1.10
        subnet: 255.255.255.0
        tx_power: "30"
        mode: mesh
    gs:
        api_version: 2
        ssid: default-gs
        key: "foobar"
        enc: wep
        ap_mac: "00:11:22:33:44:55"
        country: cn
        frequency: "5745"
        ip: 192.168.32.10
        subnet: 255.255.255.0
        tx_power: "30"
        mode: mesh
```