### PR TITLE
Update entrypoint.sh

### DIFF
--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -105,8 +105,8 @@ EOF
   /usr/sbin/hostapd -B /var/run/hostapd.conf -f /tmp/hostapd.log
   # Bridge AP and Mesh
   brctl addif br-lan bat0 "$ifname_ap"
-  ifconfig br-lan "192.168.1.20" netmask "255.255.255.0"
-  ifconfig br-lan up
+  ifconfig br-lan "192.168.1.20" netmask "255.255.255.0" 
+  ifconfig br-lan mtu 1400 up
   echo
   ifconfig br-lan
   # Add forwading rules from AP to bat0 interface


### PR DESCRIPTION
By default, the MTU size is set to 1500. This is not working with eth+bat0 bridge.  With MTU 1400 it works.