### PR TITLE
P2p scc single radio mode cfg

### DIFF
--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -158,7 +158,7 @@ elif [ "$mode" == "ap+mesh_p2p" ]; then
   # AP setup
 
   pcie_radio_mac="$(ip -brief link | grep "$wifidev" | awk '{print $3; exit}')"
-  ssid="lite#$(echo "$pcie_radio_mac" | cut -b 13-14,16-17)"
+  ssid="p2p#$(echo "$pcie_radio_mac" | cut -b 13-14,16-17)"
 
   ifname_ap="$wifidev-1"
   iw dev "$wifidev" interface add "$ifname_ap" type managed addr "00:01:$(echo "$pcie_radio_mac" | cut -b 7-17)"

--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -138,7 +138,9 @@ EOF
 elif [ "$mode" == "ap+mesh_p2p" ]; then
   # chanbw config
   mount -t debugfs none /sys/kernel/debug
-  echo 20 > /sys/kernel/debug/ieee80211/phy0/ath9k/chanbw
+  if [ -f "/sys/kernel/debug/ieee80211/phy0/ath9k/chanbw" ]; then
+      echo 20 > /sys/kernel/debug/ieee80211/phy0/ath9k/chanbw
+  fi
 
   wifidev="$(ifconfig -a | grep wlp1* | awk -F':' '{ print $1 }')"
   # Radio parameters


### PR DESCRIPTION
Add support for peer SAP connection using Single channel concurrency with single radio for comms docker container for 5/10/2 MHZ BW(ath9k) and 20/40/80 MHZ BW(ath10k)

phy#0
	Interface wlp1s0
		ifindex 64
		wdev 0x4
		addr 00:30:1a:4f:8d:ca
		type mesh point
		txpower 27.00 dBm
		multicast TXQ:
			qsz-byt	qsz-pkt	flows	drops	marks	overlmt	hashcol	tx-bytes	tx-packets
			0	0	0	0	0	0	0	0		0
	Interface wlp1s0-1
		ifindex 58
		wdev 0x3
		addr 00:01:1a:4f:8d:ca
		ssid p2p#8dca
		type AP
		channel 161 (5805 MHz), width: 20 MHz, center1: 5805 MHz
		txpower 27.00 dBm
		multicast TXQ:
			qsz-byt	qsz-pkt	flows	drops	marks	overlmt	hashcol	tx-bytes	tx-packets
			0	0	43	0	0	0	0	5844		43

Mesh configuration: ( refer to CONCURRENCY and MCC_CHANNEL)
root@br_hardened:~# docker exec -ti mesh_comms_vm /bin/bash
bash-5.1# cat /opt/mesh.conf 
MODE=mesh
IP=192.168.2.1
MASK=255.255.255.0
MAC=00:11:22:33:44:55
KEY=1234567890
ESSID=gold
FREQ=5805
TXPOWER=30
COUNTRY=AE
MESH_VIF=wlp1s0
PHY=phy0
#CONCURRENCY configuration
CONCURRENCY=ap+mesh_p2p
MCC_CHANNEL=5805


ping d2d peer:
bash-5.1# ping 192.168.2.2
64 bytes from 192.168.2.2: icmp_seq=3 ttl=64 time=947 ms
64 bytes from 192.168.2.2: icmp_seq=4 ttl=64 time=1.95 ms
64 bytes from 192.168.2.2: icmp_seq=5 ttl=64 time=1.61 ms
64 bytes from 192.168.2.2: icmp_seq=6 ttl=64 time=104 ms
64 bytes from 192.168.2.2: icmp_seq=7 ttl=64 time=23.3 ms


