### PR TITLE
fog-ros-baseimage: include eol distros (galactic)

### DIFF
--- a/modules/mesh_com/Dockerfile
+++ b/modules/mesh_com/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:builder-3dcb78d AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage:builder-ae21266 AS builder
 
 # Install build dependencies
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
@@ -23,7 +23,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-3dcb78d
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-ae21266
 
 # wpasupplicant pinned as to receive SSRC version (and not Ubuntu) of it which has some mesh-related customizations:
 # https://github.com/tiiuae/wpa

--- a/modules/mesh_com/Dockerfile.build_env
+++ b/modules/mesh_com/Dockerfile.build_env
@@ -35,7 +35,7 @@ RUN chown -R builder:builder /$PACKAGE_NAME
 
 USER builder
 
-RUN rosdep update
+RUN rosdep update --include-eol-distros
 
 VOLUME /$PACKAGE_NAME/sources
 WORKDIR /$PACKAGE_NAME/sources


### PR DESCRIPTION
Already existing branches without this fix will fail to build due to ROS2 Galactic being end-of-life since 9.12.2022.