### PR TITLE
Bridge certain ethernet port with mesh network based on detected HW

### DIFF
--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-COMMS_PCB_VERSION_FILE="/opt/comms_pcb_version"
+COMMS_PCB_VERSION_FILE="/opt/hardware/comms_pcb_version"
 
 calculate_wifi_channel()
 {

--- a/modules/utils/docker/start-docker.sh
+++ b/modules/utils/docker/start-docker.sh
@@ -43,10 +43,10 @@ elif [ "$OS" == "Buildroot" ]; then
             mkdir -p /opt/container-data/mesh
             mv /opt/mesh_com* /opt/container-data/mesh/
         fi
-        # Copy hardware identificatin file into container-data 
+        # Copy hardware identification file into container-data 
         if [ -f "/etc/comms_pcb_version" ]; then
-            mkdir -p /opt/container-data/hardware
-            cp /etc/comms_pcb_version /opt/container-data/hardware/comms_pcb_version       
+            mkdir -p /opt/container-data/mesh/hardware
+            cp /etc/comms_pcb_version /opt/container-data/mesh/hardware/comms_pcb_version       
         fi
         # change rootfs location once its mounted in dedicated partation
         if [ -f "/root/rootfs.tgz" ]; then

--- a/modules/utils/docker/start-docker.sh
+++ b/modules/utils/docker/start-docker.sh
@@ -43,6 +43,11 @@ elif [ "$OS" == "Buildroot" ]; then
             mkdir -p /opt/container-data/mesh
             mv /opt/mesh_com* /opt/container-data/mesh/
         fi
+        # Copy hardware identificatin file into container-data 
+        if [ -f "/etc/comms_pcb_version" ]; then
+            mkdir -p /opt/container-data/hardware
+            cp /etc/comms_pcb_version /opt/container-data/hardware/comms_pcb_version       
+        fi
         # change rootfs location once its mounted in dedicated partation
         if [ -f "/root/rootfs.tgz" ]; then
             echo "import rootfs.tgz commms vm"

--- a/modules/utils/docker/start-docker.sh
+++ b/modules/utils/docker/start-docker.sh
@@ -43,10 +43,12 @@ elif [ "$OS" == "Buildroot" ]; then
             mkdir -p /opt/container-data/mesh
             mv /opt/mesh_com* /opt/container-data/mesh/
         fi
-        # Copy hardware identification file into container-data 
-        if [ -f "/etc/comms_pcb_version" ]; then
-            mkdir -p /opt/container-data/mesh/hardware
-            cp /etc/comms_pcb_version /opt/container-data/mesh/hardware/comms_pcb_version       
+        # Copy hardware identification file into container-data
+        if [ ! -d "/opt/container-data/mesh/hardware" ]; then 
+            if [ -f "/etc/comms_pcb_version" ]; then
+                mkdir -p /opt/container-data/mesh/hardware
+                cp /etc/comms_pcb_version /opt/container-data/mesh/hardware/comms_pcb_version
+            fi
         fi
         # change rootfs location once its mounted in dedicated partation
         if [ -f "/root/rootfs.tgz" ]; then


### PR DESCRIPTION
Jira-ID: WC-210 mesh_com_1.0: Ethernet eth0 not bridged with mesh network

Detected HW version is brought visible inside docker by copying /etc/comms_pcb_version file into container-data. HW version is used to select what ethernet port is bridged with mesh network.