### PR TITLE
Fixed Security beat and Quarantine issues

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/1_5/main.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main.py
@@ -83,7 +83,8 @@ def quaran(ness_result, q, sectable, ma, mapp):
     for node in ness_result:
         if ness_result[node] == 194 or (not q.empty() and q.get() == 'malicious'):
             print("Malicious Node: ", ness.remapping(mapp, node))
-            mac = sectable.iloc[node]['IP']
+            #mac = sectable.iloc[node]['IP']
+            mac = sectable[sectable['ID'] == ness.remapping(mapp, node)]['IP'].unique()[0]
             threading.Thread(target=ma.server, args=(f"malicious: {mac}", True), daemon=True).start()
             threading.Thread(target=qua.block, args=(mac,), daemon=True).start()
             for i in range(quarantineTime, 0, -1):

--- a/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
@@ -147,16 +147,22 @@ def show_neighbors():
 def sbeat():
     os.system('clear')
     original_time = time()
-    end_time = 5  # one minute
-    sec_beat_time = 5
+    end_time = 100
+    sec_beat_time = 120
     os.system('clear')
     print('\'SecBeat\'')
+    print(f'Running SecBeat every {sec_beat_time} seconds, during {end_time} seconds')
+    sec_beat_start_time = original_time
+    count = 1
+    print('\nSecurity beat no. ', count)
     sec_beat(myID)
-    print(f'Running SecBeat every {sec_beat_time} seconds, during {end_time} minutes')
     while time() < original_time + end_time:
-        if mesh_utils.verify_mesh_status():  # verifying that mesh is running
-            sleep(sec_beat_time - time() % sec_beat_time)  # sec beat time
+        if mesh_utils.verify_mesh_status() and time() - sec_beat_start_time >= sec_beat_time:  # verifying that mesh is running
+            #sleep(sec_beat_time - time() % sec_beat_time)  # sec beat time
+            count = count + 1
+            print('\nSecurity beat no. ', count)
             sec_beat(myID)
+            sec_beat_start_time = time()
 
 def extable():
     os.system('clear')


### PR DESCRIPTION
* main.py --> compute malicious node's mac address using the malicious node ID instead of security table index to avoid blocking the wrong node
* main_with_menu.py --> modified security beat to run every security beat period synchronously (previously it waited for a fixed period after a security beat completion to start the next beat, which may happen at different times for different nodes)

Jira_Id : MSS15-24

Signed-off-by: Selina Shrestha <selina.shrestha@tii.ae>