### PR TITLE
Fixed malicious node decision, Auth AP server for mutual authenticati on not restarting during docker execution, unparallel blocking of nodes in quarantine

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/1_5/features/ness/ness_main.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/ness/ness_main.py
@@ -288,7 +288,7 @@ class NESS:
             count_malicious = flags.count(NodeType.MALICIOUS)
             if count_malicious == len(num_servers):
                 result[node_id] = NodeType.MALICIOUS
-            elif count_malicious > len(num_servers) / 2:
+            elif count_malicious >= len(num_servers) / 2:
                 result[node_id] = NodeType.SUSPICIOUS
             else:
                 result[node_id] = NodeType.BENIGN

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/quarantine/quarantine.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/quarantine/quarantine.py
@@ -11,13 +11,17 @@ class Quarantine:
     def __init__(self):
         self.interface = mesh_utils.get_mesh_interface('bat0')
 
-    def block(self, ip):
+    def block(self, ip, quarantineTime):
         #command = [str(script_path) + '/traffic_block.sh', mac, self.interface]
         #command = ['iptables', '-A', 'INPUT', '-p', 'ALL', '-m', 'mac', '--mac-source', mac, '-j', 'DROP']
         command = ['iptables', '-I', 'INPUT', '-p', 'ALL', '-s', ip, '-j', 'DROP']
         subprocess.call(command, shell=False)
         print(f'blocking IP: {str(ip)} on interface {str(self.interface)}')
         self.iptablesSave()
+        for i in range(quarantineTime, 0, -1):
+            print(f"Blocking IP: {str(ip)} for {str(i)} seconds", end='\r')
+            time.sleep(1)
+        self.unblock(ip)
 
 
     def unblock(self, ip):

--- a/modules/sc-mesh-secure-deployment/src/1_5/main.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main.py
@@ -86,11 +86,7 @@ def quaran(ness_result, q, sectable, ma, mapp):
             #mac = sectable.iloc[node]['IP']
             mac = sectable[sectable['ID'] == ness.remapping(mapp, node)]['IP'].unique()[0]
             threading.Thread(target=ma.server, args=(f"malicious: {mac}", True), daemon=True).start()
-            threading.Thread(target=qua.block, args=(mac,), daemon=True).start()
-            for i in range(quarantineTime, 0, -1):
-                print(f"Blocking Node: {str(node)} for {str(i)} seconds", end='\r')
-                sleep(1)
-            threading.Thread(target=qua.unblock, args=(mac,), daemon=True).start()
+            threading.Thread(target=qua.block, args=(mac, quarantineTime), daemon=True).start()
         else:
             print("Nothing to do")
 

--- a/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
@@ -69,7 +69,7 @@ def MA():
         AUTHSERVER = True
     p = threading.Thread(target=aux_auth, daemon=True, args=(semasphore,))
     p.start()
-
+    return p
 
 def only_mesh():
     os.system('clear')

--- a/modules/sc-mesh-secure-deployment/src/1_5/old_main.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/old_main.py
@@ -1,6 +1,7 @@
 import yaml
 from main_with_menu import *
 
+MA_thread = None
 def readfile():
     with open("features.yaml", "r") as stream:
         try:
@@ -10,8 +11,9 @@ def readfile():
 
 
 def initialize(feature):
+    global MA_thread
     if feature == 'mutual':
-            MA()
+            MA_thread = MA()
     if feature == 'continuous':
             CA()
     if feature == 'NESS':
@@ -31,4 +33,6 @@ if __name__ == "__main__":
     for index in features:
         if features[index]:
             initialize(index)
-
+    # wait for Auth_AP to start in background for future nodes
+    if MA_thread:
+        MA_thread.join()


### PR DESCRIPTION
* ness_main.py --> modified malicious node decision so that a node gets flagged as malicious if half or more of the nodes agree (instead of more than half)
* main_with_menu.py --> Return the thread that restarts Auth AP in MA() function
* old_main.py --> Modified to wait for thread returned by MA() to complete before exiting the script
* main.py --> Removed time counter for block period inside the for loop in quaran() function
* quarantine.py --> Added time counter for blocking period inside block function as it is called parallelly

Jira_Id : MSS15-26

Signed-off-by: Selina Shrestha <selina.shrestha@tii.ae>