### PR TITLE
Added Security Beat to Docker Execution

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/1_5/features.yaml
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features.yaml
@@ -2,5 +2,6 @@ only_mesh: false
 NESS: false
 continuous: false
 mutual: true
+secbeat: true
 quarantine: false
 mesh: true

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/server.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/server.py
@@ -281,7 +281,7 @@ def initiate_server(ip, return_dict, id_dict, num_neighbors, ips_sectable, logge
 
     try:
         s = socket.socket()  # create server socket s with default param ipv4, TCP
-        s.settimeout(45)  # Setting timeout to prevent infinite blocking at s.accept() when the client node is not on
+        s.settimeout(20)  # Setting timeout to prevent infinite blocking at s.accept() when the client node is not on
         # to accept connections from clients, bind IP of server, a port number to the server socket
         s.bind((ip, 9999))
         print('Socket Created')

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/mutual/mutual.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/mutual/mutual.py
@@ -331,7 +331,11 @@ class Mutual:
         except ConnectionRefusedError:
             time.sleep(7)
             fs.client_auth(cliID, addr[0], encrypt_pass, self.interface)
-        client_mesh_ip, _ = fs.server_auth(self.myID, self.interface)
+        try:
+            client_mesh_ip, _ = fs.server_auth(self.myID, self.interface)
+        except Exception as e:
+            time.sleep(10)
+            client_mesh_ip, _ = fs.server_auth(self.myID, self.interface)
         if self.debug:
             print(f'Client Mesh IP: {str(client_mesh_ip)}')
         try:
@@ -340,7 +344,11 @@ class Mutual:
         except ConnectionRefusedError:
             time.sleep(7)
             fs.client_auth(cliID, addr[0], my_mac_mesh.encode(), self.interface)
-        client_mac, _ = fs.server_auth(self.myID, self.interface)
+        try:
+            client_mac, _ = fs.server_auth(self.myID, self.interface)
+        except Exception as e:
+            time.sleep(10)
+            client_mac, _ = fs.server_auth(self.myID, self.interface)
         if self.debug:
             print(f'Client Mesh MAC: {str(client_mesh_ip)}')
         try:
@@ -408,17 +416,25 @@ class Mutual:
                 self.start_mesh()
                 try:
                     fs.client_auth(cliID, addr[0], self.my_ip_mesh.encode(), self.interface)  # send my mesh ip
-                except ConnectionRefusedError:
+                except Exception as e:
                     time.sleep(2)
-                    fs.client_auth(cliID, addr[0], self.my_ip_mesh.encode(), self.interface)
+                    try:
+                        fs.client_auth(cliID, addr[0], self.my_ip_mesh.encode(), self.interface)
+                    except Exception as e:
+                        time.sleep(10)
+                        fs.client_auth(cliID, addr[0], self.my_ip_mesh.encode(), self.interface)  # send my mesh ip
                 client_mac, _ = fs.server_auth(self.myID, self.interface)
                 print(f'Client MAC: {str(client_mac)}')
                 try:
                     time.sleep(2)
                     fs.client_auth(cliID, addr[0], self.my_mac_mesh.encode(), self.interface)  # send my mac
-                except ConnectionRefusedError:
+                except Exception as e:
                     time.sleep(2)
-                    fs.client_auth(cliID, addr[0], self.my_mac_mesh.encode(), self.interface)
+                    try:
+                        fs.client_auth(cliID, addr[0], self.my_mac_mesh.encode(), self.interface)
+                    except Exception as e:
+                        time.sleep(10)
+                        fs.client_auth(cliID, addr[0], self.my_mac_mesh.encode(), self.interface)
                 client_mesh_ip, _ = fs.server_auth(self.myID, self.interface)
             elif pri.verify_certificate(sig, node_name, self.digest(), self.root_cert):
                 # print(colored('> Valid Certificate', 'green'))

--- a/modules/sc-mesh-secure-deployment/src/1_5/main.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main.py
@@ -6,7 +6,14 @@ def continuous_authentication(sectable, myID):
     aux = sectable.iloc[:, :5]
     sectable = aux.drop_duplicates()
     sectable.drop(sectable.loc[sectable['MAC'] == '----'].index, inplace=True) # To avoid duplicates after exchange table for mesh neighbors not originally mutually authenticated
-    loop_ca = asyncio.get_event_loop()
+    # loop_ca = asyncio.get_event_loop()
+    try:
+        loop_ca = asyncio.get_event_loop()
+    except RuntimeError as ex:
+        if "There is no current event loop in thread" in str(ex):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            loop_ca = asyncio.get_event_loop()
     ca_task = loop_ca.create_task(ca_utils.launchCA(sectable))
     with contextlib.suppress(asyncio.CancelledError):
         result = loop_ca.run_until_complete(asyncio.gather(ca_task))
@@ -103,7 +110,6 @@ def sec_beat(myID):
     ness_result, mapp = decision_engine(global_table, ma, q)
     #quaran(ness_result, q, sectable, ma, mapp)
     quaran(ness_result, q, global_table, ma, mapp)
-
 
 def mutual_authentication():
     print("Starting Mutual Authentication")

--- a/modules/sc-mesh-secure-deployment/src/1_5/old_main.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/old_main.py
@@ -19,7 +19,7 @@ def initialize(feature):
     if feature == 'NESS':
             DE()
     if feature == 'secbeat':
-            sbeat()
+            sbeat_client()
     if feature == 'quarantine':
             Quarantine()
     if feature == 'only_mesh':


### PR DESCRIPTION
* features.yaml --> set secbeat: true
* main_with_menu.py --> Added functions sbeat_client(), sbeat_server() and modified sbeat() [port 6007 used to broadcast security beat]
* old_main.py --> Modified to call sbeat_client() if feature = 'secbeat'
* main.py --> continuous_authentication() modified to create new event loop if an event loop is not already present
* mutual.py --> Socket creation in send_password() modified to wait for 10 seconds in case of an exception [if sbeat coincides with MA, the socket needs to wait for a while]
* continuous/server.py --> reduced socket timeout in initiate_server() from 45 to 20 seconds in case the client is not responsive

Jira_Id : MSS15-28

Signed-off-by: Selina Shrestha <selina.shrestha@tii.ae>