### PR TITLE
Fixed issues in getting mesh neighbor IPs and automated security beat broadcast IP selection

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/1_5/common/mesh_utils.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/common/mesh_utils.py
@@ -71,63 +71,40 @@ def get_mesh_interface(pattern):
     else:
         return pre[0]
 
-
 def get_neighbors_ip():
-    # some global vars
-    num_threads = 15
-    ips_q = queue.Queue()
-    out_q = queue.Queue()
-    my_ip = get_mesh_ip_address()
-    aux = my_ip.split('.')[0:3]
-    # build IP array
     ips = []
     final = []
-    for i in range(1, 10):
-        ips.append('.'.join(aux) + '.' + str(i))
+    my_ip = get_mesh_ip_address()
+    aux = my_ip.split('.')[0:3]
+    for i in range(1, 255):
+        if str(i) != my_ip.split('.')[3]:
+            ips.append('.'.join(aux) + '.' + str(i)) # All ips in the mesh subnet except my_ip
 
-    def thread_pinger(i, q):
-        """Pings hosts in queue"""
-        while True:
-            # get an IP item form queue
-            ip = q.get()
-            # ping it
-            args = ['/bin/ping', '-c', '1', '-W', '1', str(ip)]
-            p_ping = subprocess.Popen(args,
-                                      shell=False,
-                                      stdout=subprocess.PIPE)
-            # save ping stdout
-            p_ping_out = str(p_ping.communicate()[0])
+    threads = []
 
-            if (p_ping.wait() == 0):
-                # rtt min/avg/max/mdev = 22.293/22.293/22.293/0.000 ms
-                search = re.search(r'rtt min/avg/max/mdev = (.*)/(.*)/(.*)/(.*) ms',
-                                   p_ping_out, re.M | re.I)
-                out_q.put(str(ip))
+    def thread_pinger(ip):
+        #args = ['/bin/ping', '-c', '1', '-W', '1', str(ip)]
+        args = ['/bin/ping', '-c', '1', str(ip)]
+        p_ping = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE)
+        # save ping stdout
+        p_ping_out = str(p_ping.communicate()[0])
 
-            # update queue : this ip is processed
-            q.task_done()
+        if (p_ping.wait() == 0):
+            # rtt min/avg/max/mdev = 22.293/22.293/22.293/0.000 ms
+            # search = re.search(r'rtt min/avg/max/mdev = (.*)/(.*)/(.*)/(.*) ms',p_ping_out, re.M | re.I)
+            # out_q.put(str(ip))
+            final.append(ip)
 
-    # start the thread pool
-    for i in range(num_threads):
-        worker = Thread(target=thread_pinger, args=(i, ips_q), daemon=True).start()
-
-    # fill queue
     for ip in ips:
-        ips_q.put(ip)
+        worker = Thread(target=thread_pinger, args=(ip,), daemon=True)
+        threads.append(worker)
+        worker.start()
 
-    # wait until worker threads are done to exit
-    ips_q.join()
+    for thread in threads:
+        thread.join()
 
-    # print result
-    while True:
-        try:
-            msg = out_q.get_nowait()
-        except queue.Empty:
-            break
-        final.append(msg)
-    final.remove(my_ip)
+    #final.remove(my_ip)
     return final
-
 
 def get_arp():
     neig = {}

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/utils.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/utils.py
@@ -34,10 +34,11 @@ async def launchCA(sectable):
     return_dict = manager.dict()
     id_dict = manager.dict()
 
-    ip2_send = list(set(sectable['IP'].tolist() + mesh_utils.get_neighbors_ip()))
+    neighbor_ips = mesh_utils.get_neighbors_ip()
+    ip2_send = list(set(sectable['IP'].tolist() + neighbor_ips))
 
     #ip2_send = list(set(sectable['IP'].tolist() + list(neigh.keys())))
-    print('Checkpoint, neighbor IPs = ', mesh_utils.get_neighbors_ip())
+    print('Checkpoint, neighbor IPs = ', neighbor_ips)
     print('Checkpoint, ip2send = ', ip2_send)
     neigh = mesh_utils.get_arp()
     print('Checkpoint, IP_get_arp = ', list(neigh.keys()))

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/utils/utils.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/utils/utils.py
@@ -137,7 +137,7 @@ def exchange_server(debug=False):
         except socket.timeout:
             print('Socket timeout')
             break # If timeout, break while loop
-        sock.settimeout(15)  # Setting timeout to exit infinite loop if nothing is received for 15 seconds
+        sock.settimeout(20)  # Setting timeout to exit infinite loop if nothing is received for 15 seconds
 
 def exchange_client(IP, message, debug=False):
     print('Checkpoint inside exchange_client')

--- a/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
@@ -33,7 +33,7 @@ def banner():
 AUTHSERVER = False
 mut = mutual.Mutual(MUTUALINT)
 myID = mut.myID
-sec_beat_time = 100  # Security beat period in seconds
+sec_beat_time = 120  # Security beat period in seconds
 
 def print_menu():
     banner()
@@ -82,7 +82,7 @@ def only_mesh():
         sleep(2)
         if mesh_utils.verify_mesh_status():  # verifying that mesh is running
             print("Mesh Running")
-            mesh_utils.get_neighbors_ip()
+            #mesh_utils.get_neighbors_ip()
             neigh = mesh_utils.get_arp()
             for ne in neigh:
                 info = {'ID': ne, 'MAC': neigh[ne], 'IP': ne,
@@ -148,7 +148,7 @@ def show_neighbors():
 def sbeat():
     #os.system('clear')
     original_time = time()
-    end_time = 1000 # Total time to run security beat in seconds
+    end_time = 1200 # Total time to run security beat in seconds
     #os.system('clear')
     print('\'SecBeat\'')
     print(f'Running SecBeat every {sec_beat_time} seconds, during {end_time} seconds')
@@ -200,18 +200,20 @@ def sbeat_client():
     threading.Thread(target=sbeat, daemon=True, args=()).start()
 
 def sbeat_server():
+    my_ip = mesh_utils.get_mesh_ip_address()
+    broadcast_ip = '.'.join(my_ip.split('.')[0:3]) + '.255' # bat0 broadcast ip
     sbeat_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)  # UDP
     sbeat_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sbeat_sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     sbeat_sock.setblocking(False)
     print("Broadcasting security beat")
-    sbeat_sock.sendto(bytes('SecBeat', "utf-8"),('10.10.10.255', 6007))  # mesh_utils.get_mesh_ip_address() # bat0 broadcast ip
+    sbeat_sock.sendto(bytes('SecBeat', "utf-8"), (broadcast_ip, 6007))  # mesh_utils.get_mesh_ip_address() # bat0 broadcast ip
     sleep(0.1)
-    sbeat_sock.sendto(bytes('SecBeat', "utf-8"), ('10.10.10.255', 6007))
+    sbeat_sock.sendto(bytes('SecBeat', "utf-8"), (broadcast_ip, 6007))
     sleep(0.1)
-    sbeat_sock.sendto(bytes('SecBeat', "utf-8"), ('10.10.10.255', 6007))
+    sbeat_sock.sendto(bytes('SecBeat', "utf-8"), (broadcast_ip, 6007))
     sleep(0.1)
-    sbeat_sock.sendto(bytes('SecBeat', "utf-8"), ('10.10.10.255', 6007))
+    sbeat_sock.sendto(bytes('SecBeat', "utf-8"), (broadcast_ip, 6007))
     sbeat_sock.close()
 
 def extable():
@@ -219,8 +221,8 @@ def extable():
     print('\'Exchange Security Table\'')
     table = 'auth/dev.csv'
     try:
-        mesh_utils.get_neighbors_ip()
         """
+        mesh_utils.get_neighbors_ip()
         try:
             sectable = pd.read_csv(table)
             sectable.drop_duplicates(inplace=True)


### PR DESCRIPTION

* mesh_utils.py -> fixed get_neighbors_ip() to get IPs with last octets from 1 to 255 (previously only checked single digit IPs)
* main_with_menu.py --> computed broadcast IP for security beat automatically from bat0 IP, increased security beat period
* continuous/utils.py -> replaced calling get_neighbors_ip() multiple times with just once (as it is takes ~5 seconds each time)
* utils/utils.py -> increased exchange table socket timeout to 20 seconds from 15 seconds

Jira_Id : MSS15-30

Signed-off-by: Selina Shrestha <selina.shrestha@tii.ae>