### PR TITLE
Fix only_mesh + security beat execution in docker, automatic password for only_mesh usage, bug fixes from code clean up

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/1_5/features.yaml
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features.yaml
@@ -5,3 +5,4 @@ mutual: true
 secbeat: true
 quarantine: false
 mesh: true
+provisioning: false

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/server.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/server.py
@@ -281,9 +281,9 @@ def multi_threaded_client(c, addr, lock, return_dict, id_dict, ips_sectable, log
 
 def initiate_server(ip, return_dict, id_dict, num_neighbors, ips_sectable, logger=None):
 
-    try:
-        with socket.socket() as s:  # create server socket s with default param ipv4, TCP
-            s.settimeout(20)  # Setting timeout to prevent infinite blocking at s.accept() when the client node is not on
+    with socket.socket() as s:  # create server socket s with default param ipv4, TCP
+        try:
+            s.settimeout(30)  # Setting timeout to prevent infinite blocking at s.accept() when the client node is not on
             # to accept connections from clients, bind IP of server, a port number to the server socket
             s.bind((ip, 9999))
             print('Socket Created')
@@ -294,32 +294,32 @@ def initiate_server(ip, return_dict, id_dict, num_neighbors, ips_sectable, logge
 
             if logger:
                 logger.info("Server socket created at (%s, 9999)", ip)
-    except socket.error:
-        print("Server socket creation failed")
-        if logger:
-            logger.error("Server socket creation failed")
-        return
+        except socket.error:
+            print("Server socket creation failed")
+            if logger:
+                logger.error("Server socket creation failed")
+            return
 
-    threads = []
+        threads = []
 
-    #while True:
-    for i in range(0, num_neighbors):
-        print("Server inside for loop, i = ", i)
-        lock = Lock()
-        # accept connection from client
-        c, addr = s.accept()
-        print('Connected to client', c)
-        print('Client address:', addr)
-        print(' ')
-        return_dict[addr[0]] = []
-        # start thread to handle client
-        thread = Thread(target=multi_threaded_client, args=(c, addr, lock, return_dict, id_dict, ips_sectable, logger), daemon=True)
-        threads.append(thread)
-        thread.start()
+        #while True:
+        for i in range(0, num_neighbors):
+            print("Server inside for loop, i = ", i)
+            lock = Lock()
+            # accept connection from client
+            c, addr = s.accept()
+            print('Connected to client', c)
+            print('Client address:', addr)
+            print(' ')
+            return_dict[addr[0]] = []
+            # start thread to handle client
+            thread = Thread(target=multi_threaded_client, args=(c, addr, lock, return_dict, id_dict, ips_sectable, logger), daemon=True)
+            threads.append(thread)
+            thread.start()
 
-    for thread in threads:
-        thread.join()
-    #c.send(bytes('Closing connection', 'utf-8'))
-    #c.close()  # close client socket
-    print('Connection closed')
+        for thread in threads:
+            thread.join()
+        #c.send(bytes('Closing connection', 'utf-8'))
+        #c.close()  # close client socket
+        print('Connection closed')
 

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/utils.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/continuous/utils.py
@@ -36,6 +36,7 @@ async def launchCA(sectable):
 
     neighbor_ips = mesh_utils.get_neighbors_ip()
     ip2_send = list(set(sectable['IP'].tolist() + neighbor_ips))
+    if myip in ip2_send: ip2_send.remove(myip) # remove node's own IP
 
     #ip2_send = list(set(sectable['IP'].tolist() + list(neigh.keys())))
     print('Checkpoint, neighbor IPs = ', neighbor_ips)
@@ -43,7 +44,7 @@ async def launchCA(sectable):
     neigh = mesh_utils.get_arp()
     print('Checkpoint, IP_get_arp = ', list(neigh.keys()))
 
-    num_neighbors = len(ip2_send) - 1 # Number of neighbor nodes that need to be authenticated
+    num_neighbors = len(ip2_send) # Number of neighbor nodes that need to be authenticated
     server_proc = ca_server(myip, return_dict, id_dict, num_neighbors, list(set(sectable['IP'].tolist())))
 
     for IP in ip2_send:

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/mba/mba.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/mba/mba.py
@@ -16,44 +16,44 @@ class MBA:
         self.add = '.'.join(aux)
 
     def client(self, q, debug=False, logger=None):
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            try:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 sock.bind(("0.0.0.0", 6006))
                 if logger:
                     logger.info("Client socket created")
-        except socket.error:
-            print("Client socket creation failed")
-            if logger:
-                logger.error("Client socket creation failed")
-            return
-        while True:
-            data, addr = sock.recvfrom(1024)
-            print("mba: message received")
-            if debug:
-                print(data, addr)
-            q.put(data)
+            except socket.error:
+                print("Client socket creation failed")
+                if logger:
+                    logger.error("Client socket creation failed")
+                return
+            while True:
+                data, addr = sock.recvfrom(1024)
+                print("mba: message received")
+                if debug:
+                    print(data, addr)
+                q.put(data)
 
     def server(self, message, debug=False, logger=None):
         num_message = 5
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock: # UDP
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock: # UDP
+            try:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 sock.setblocking(False)
                 if logger:
                     logger.info("Server socket created")
-        except socket.error:
-            print("Server socket creation failed")
-            if logger:
-                logger.error("Server socket creation failed")
-            return
-        while num_message:
-            if debug:
-                print(f"this is server and it will send message {num_message} more times")
-            sock.sendto(bytes(message, "utf-8"), (self.add, 6006))
-            num_message -= 1
-            sleep(1)
+            except socket.error:
+                print("Server socket creation failed")
+                if logger:
+                    logger.error("Server socket creation failed")
+                return
+            while num_message:
+                if debug:
+                    print(f"this is server and it will send message {num_message} more times")
+                sock.sendto(bytes(message, "utf-8"), (self.add, 6006))
+                num_message -= 1
+                sleep(1)
 
     def terminate(self):
         del self

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/mutual/mutual.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/mutual/mutual.py
@@ -54,20 +54,6 @@ except FileNotFoundError:
     print("Root certificate not found. Need to get it from provisioning")
     sys.exit()
 
-
-
-def create_table():
-    '''
-    Function to create table of authenticated devices
-    '''
-    columns = ['ID', 'MAC', 'IP', 'PubKey_fpr', 'MA_level']
-    if not path.isfile('auth/dev.csv'):
-        table = pd.DataFrame(columns=columns)
-        table.to_csv('auth/dev.csv', header=columns, index=False)
-    else:
-        table = pd.read_csv('auth/dev.csv')
-    return table
-
 class Mutual:
     """
     set_level function to establish trust level of an imported key
@@ -89,9 +75,20 @@ class Mutual:
         print("loading root_cert")
         pri.import_cert(root_cert, 'root')
         print("my ID: ", self.myID)
-        self.table = create_table()
+        self.table = self.create_table()
         #self.salt = os.urandom(16)
 
+    def create_table(self):
+        '''
+        Function to create table of authenticated devices
+        '''
+        columns = ['ID', 'MAC', 'IP', 'PubKey_fpr', 'MA_level']
+        if not path.isfile('auth/dev.csv'):
+            table = pd.DataFrame(columns=columns)
+            table.to_csv('auth/dev.csv', header=columns, index=False)
+        else:
+            table = pd.read_csv('auth/dev.csv')
+        return table
 
     def update_table(self, info):
         '''
@@ -161,7 +158,7 @@ class Mutual:
         '''
         with open(root_cert, 'rb') as file:
             root_cert_data = file.read()
-        message = self.message_generator(root_cert_data.read())
+        message = self.message_generator(root_cert_data)
         try:
             fs.client_auth(candidate, serverIP, json.dumps(message).encode(), self.interface)
             if logger:

--- a/modules/sc-mesh-secure-deployment/src/1_5/features/utils/utils.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/features/utils/utils.py
@@ -130,7 +130,7 @@ def exchange_server(debug=False):
             except socket.timeout:
                 print('Socket timeout')
                 break # If timeout, break while loop
-            sock.settimeout(20)  # Setting timeout to exit infinite loop if nothing is received for 15 seconds
+            sock.settimeout(25)  # Setting timeout to exit infinite loop if nothing is received for 15 seconds
 
 def exchange_client(IP, message, debug=False):
     print('Checkpoint inside exchange_client')

--- a/modules/sc-mesh-secure-deployment/src/1_5/header.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/header.py
@@ -18,6 +18,7 @@ import contextlib
 import pandas as pd
 import numpy as np
 from features.utils import utils as ut
+from hashlib import blake2b
 import yaml
 
 from common import ConnectionMgr

--- a/modules/sc-mesh-secure-deployment/src/1_5/main.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main.py
@@ -30,23 +30,19 @@ def only_ca(myID):
         table = 'auth/dev.csv'
         filetable = pd.read_csv(table)
         filetable.drop_duplicates(inplace=True)
-        if not filetable.empty:
-            if "Ness_Result" in filetable.columns:
-                filetable.drop(["Ness_Result"], axis=1, inplace=True)
-            sectable = continuous_authentication(filetable, myID)
+        if "Ness_Result" in filetable.columns:
+            filetable.drop(["Ness_Result"], axis=1, inplace=True)
+        sectable = continuous_authentication(filetable, myID)
+        sleep(2)
+        if sectable is not None:
+            # ut.exchage_table(sectable)
             sleep(2)
-            if sectable is not None:
-                # ut.exchage_table(sectable)
-                sleep(2)
-                if 'CA_Result' in set(sectable):
-                    sectable.to_csv(table, index=False)
-                else:
-                    sectable.to_csv(table, mode='a', header=False, index=False)
-                return sectable
-            print("End of Continuous Authentication")
-        else:
-            print("Empty Security Table")
-            sys.exit()
+            if 'CA_Result' in set(sectable):
+                sectable.to_csv(table, index=False)
+            else:
+                sectable.to_csv(table, mode='a', header=False, index=False)
+            return sectable
+        print("End of Continuous Authentication")
     except FileNotFoundError:
         print("SecTable not available. Need to be requested during provisioning")
 
@@ -125,6 +121,7 @@ def mutual_authentication():
 
 
 MA_thread = None
+sbeat_thread = None
 def readfile():
     with open("features.yaml", "r") as stream:
         try:
@@ -135,7 +132,7 @@ def readfile():
 
 
 def initialize(feature):
-    global MA_thread
+    global MA_thread, sbeat_thread
     if feature == 'mutual':
         MA_thread = MA()
     if feature == 'continuous':
@@ -143,7 +140,7 @@ def initialize(feature):
     if feature == 'NESS':
         DE()
     if feature == 'secbeat':
-        sbeat_client()
+        sbeat_thread = sbeat_client()
     if feature == 'quarantine':
         Quarantine()
     if feature == 'only_mesh':
@@ -158,3 +155,5 @@ if __name__ == "__main__":
     # wait for Auth_AP to start in background for future nodes
     if MA_thread:
         MA_thread.join()
+    if sbeat_thread:
+        sbeat_thread.join()

--- a/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
+++ b/modules/sc-mesh-secure-deployment/src/1_5/main_with_menu.py
@@ -74,6 +74,9 @@ def only_mesh():
     print('\'Run Only Mesh\'')
     mut = mutual.Mutual(MUTUALINT)
     try:
+        if not readfile()['provisioning']:
+            password = blake2b(mut.digest().encode(), digest_size=24).hexdigest()
+            co.util.update_mesh_password(password)  # update password in config file
         mut.start_mesh()
         mut.create_table()
         sleep(2)
@@ -191,7 +194,9 @@ def sbeat_client():
             break
     print("Starting security beat")
     # sbeat()
-    threading.Thread(target=sbeat, daemon=True, args=()).start()
+    sbeat_thread = threading.Thread(target=sbeat, daemon=True, args=())
+    sbeat_thread.start()
+    return sbeat_thread
 
 def sbeat_server():
     my_ip = mesh_utils.get_mesh_ip_address()


### PR DESCRIPTION

** features.yaml --> added provisioning as a feature 
** main_with_menu.py --> if provisioning is false use 24 bits hash of root_signature as mesh password, return sbeat_thread from sbeat_client() 
** main.py --> removed clause to check if security table is empty in only_ca() so that ca runs even after only_mesh, added clause to join sbeat_thread in main so that the script waits for security beat to complete before exiting during docker execution ** header.py --> added blake2b for hashing
** utils/utils.py --> increased exchange table socket timeout from 20 seconds to 25 seconds 
** mutual.py --> create table moved inside the Class, removed double read on line 161 
** mba.py --> changed indentations in client and server functions so that all the lines using sockets are inside the "with socket" clause 
** continuous/utils.py --> removed node's own IP while computing IPs to do continuous authentication with 
** continuous/server.py --> changed indentations in initiate_server function so that all the lines using sockets are inside the "with socket" clause, increased socket timeout from 20 seconds to 30 seconds

Jira_Id : MSS15-32

Signed-off-by: Selina Shrestha <selina.shrestha@tii.ae>