### PR TITLE
[MERGE READY]-Bump tiiuae/fog-ros-baseimage from v2.0.0 to v2.1.0

### DIFF
--- a/modules/mesh_com/Dockerfile
+++ b/modules/mesh_com/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.0.0 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-b1c9665 AS builder
 
 # Install build dependencies
 RUN apt update -y && apt install -y --no-install-recommends \
@@ -23,7 +23,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.0.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-b1c9665
 
 RUN apt update -y && apt install -y --no-install-recommends \
     iw \

--- a/modules/mesh_com/Dockerfile
+++ b/modules/mesh_com/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-b1c9665 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.1.0 AS builder
 
 # Install build dependencies
 RUN apt update -y && apt install -y --no-install-recommends \
@@ -23,7 +23,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-b1c9665
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.1.0
 
 RUN apt update -y && apt install -y --no-install-recommends \
     iw \


### PR DESCRIPTION
This baseimage update contains FastDDS SROS launch bugfix. Not going to be merged until it is tested on a drone.