### PR TITLE
Hotfix for issue with MCC startup in MS v1.0

### DIFF
--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -77,99 +77,6 @@ psk="ssrcdemo"
 EOF
 }
 
-#write in the dhcpd.conf and the olsrd.conf add the ipv4 subnet and the random ipv6
-create_dhcpd_config()
-{
-  SUBNET="$1"
-
-  cat > /etc/dhcp/dhcpd.conf <<- EOF
-    default-lease-time 600;
-    max-lease-time 7200;
-    ddns-update-style none;
-    authoritative;
-
-    subnet $SUBNET.0 netmask 255.255.255.0 {
-            range $SUBNET.100 $SUBNET.199;
-            option routers $SUBNET.1;
-    }
-  EOF
-  cp /dev/null /var/lib/dhcp/dhcpd.leases
-}
-create_olsrd_config()
-{
-  wifidev="$1"
-  SUBNET="$2"
-  IPV6_PREFIX="$3"
-
-  cat > /etc/olsrd/olsrd.conf <<- EOF
-  
-  LinkQualityFishEye   0
-
-  Interface "$wifidev"
-
-  {
-
-  }
-
-  IpVersion               4
-
-  LinkQualityFishEye      0
-
-  LinkQualityAlgorithm "etx_ffeth_nl80211"
-
-  # This is only here to be able to generate a
-
-  # configuration file with the script
-
-  LoadPlugin "/usr/lib/olsrd_jsoninfo.so.1.1"
-
-  {
-
-    PlParam "port"          "9090"
-
-   PlParam "accept"        "0.0.0.0"
-
-  }
-
-  # load arprefresh plugin
-
-  # - UDP packets on port 698
-
-  LoadPlugin "/usr/lib/olsrd_arprefresh.so.0.1"  
-
-  {
-
-  }
-
-  Hna4
-  {
-          $SUBNET.0 255.255.255.0
-  }
-
-  Hna6
-  {
-          $IPV6_PREFIX:0 64
-  }
-  EOF
-}
-
-
-
-create_radvd_config()
-{
-  IPV6_PREFIX="$1"
-
-  cat > /etc/radvd.conf <<- EOF
-    interface br-lan
-    {
-            AdvSendAdvert on;
-            prefix $IPV6_PREFIX:0/64 {
-            };
-    };
-  EOF
-}
-
-
 ###Deciding IP address to be assigned to br-lan from WiFi MAC
 mesh_if_mac="$(ip -brief link | grep "$mesh_if" | awk '{print $3; exit}')"
 ip_random="$(echo "$mesh_if_mac" | cut -b 16-17)"
@@ -183,6 +90,8 @@ if [ "$mode" = "sta+mesh" ]; then
   sleep 3
   udhcpc -i $iface
 elif [ "$mode" = "ap+mesh_mcc" ]; then
+  # WAR to stop AP disappearing when device connects. No idea why this fixes it, but it does.
+  # Hopefully will not occur in MS v1.5
   sleep 5
   # Create bridge br-lan
   brctl addbr br-lan
@@ -192,20 +101,7 @@ elif [ "$mode" = "ap+mesh_mcc" ]; then
   # Set frequency band and channel from given frequency
   calculate_wifi_channel "$ch"
   ifconfig $ifname_ap up
-  
-  #random generate the ipv6
-  IPV6_PREFIX=$( echo fd`dd if=/dev/urandom bs=7 count=1 status=none | xxd -p` | sed 's/\(....\)/\1:/g' )
-  ip addr add $SUBNET.1/24 dev br-lan && ip addr add $IPV6_PREFIX:1/64 dev br-lan
 
-  create_olsrd_config "wlp1s0" "$SUBNET" "$IPV6_PREFIX"
-  # FIXME: launch olsrd
-
-  create_dhcpd_config "$SUBNET"
-  dhcpd -f br-lan
-
-  create_radvd_config "$IPV6_PREFIX"
-  # FIXME: launch radvd
-  
   # AP hostapd config
 cat <<EOF >/var/run/hostapd.conf
 country_code=AE
@@ -228,8 +124,8 @@ EOF
   if [ "$algo" = "olsr" ]; then
         brctl addif br-lan "$mesh_if" "$ifname_ap"
         iptables -A FORWARD --in-interface $mesh_if -j ACCEPT
-        killall olsrd 2>/dev/null   
-        (olsrd -i wlp1s0 -d 0)&
+        killall olsrd 2>/dev/null
+        (olsrd -i br-lan -d 0)&
   else
         ##batman-adv###
         brctl addif br-lan bat0 "$ifname_ap"
@@ -335,7 +231,7 @@ EOF
 else
   brctl addbr br-lan
   # Bridge ethernet and Mesh
-  
+
   eth_port="eth1"
   if [ -f "$COMMS_PCB_VERSION_FILE" ]; then
     source "$COMMS_PCB_VERSION_FILE"

--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -124,7 +124,7 @@ EOF
   if [ "$algo" = "olsr" ]; then
         brctl addif br-lan "$mesh_if" "$ifname_ap"
         iptables -A FORWARD --in-interface $mesh_if -j ACCEPT
-        killall olsrd 2>/dev/null
+        killall olsrd 2>/dev/null   
         (olsrd -i br-lan -d 0)&
   else
         ##batman-adv###
@@ -231,7 +231,7 @@ EOF
 else
   brctl addbr br-lan
   # Bridge ethernet and Mesh
-
+  
   eth_port="eth1"
   if [ -f "$COMMS_PCB_VERSION_FILE" ]; then
     source "$COMMS_PCB_VERSION_FILE"


### PR DESCRIPTION
Adding the sleep allows the AP to come up properly. Only needed for v1.0