### PR TITLE
Fix hardcoded MCC AP channel and band.

### DIFF
--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -65,8 +65,8 @@ cat <<EOF >/var/run/hostapd.conf
 country_code=AE
 interface=$ifname_ap
 ssid=$ssid
-hw_mode=g
-channel=7
+hw_mode=$retval_band
+channel=$retval_channel
 macaddr_acl=0
 auth_algs=1
 ignore_broadcast_ssid=0


### PR DESCRIPTION
Use mesh.conf MCC_CHANNEL and automatic band calculation rather than hardcoding MCC AP to "g" and "7".