### PR TITLE
Fix e2e connectivity between laptop->csl->csl->laptop.

### DIFF
--- a/common/scripts/mesh-11s.sh
+++ b/common/scripts/mesh-11s.sh
@@ -164,7 +164,7 @@ EOF
         echo "bat0 ip address.."
         ifconfig bat0 "$2" netmask "$3"
         echo "bat0 mtu size"
-        ifconfig bat0 mtu 1460
+        ifconfig bat0 mtu 1500
         echo
         ifconfig bat0
 

--- a/common/scripts/mesh-11s.sh
+++ b/common/scripts/mesh-11s.sh
@@ -164,7 +164,7 @@ EOF
         echo "bat0 ip address.."
         ifconfig bat0 "$2" netmask "$3"
         echo "bat0 mtu size"
-        ifconfig bat0 mtu 1500
+        ifconfig bat0 mtu 1460
         echo
         ifconfig bat0
 

--- a/modules/utils/docker/bridge_settings.sh
+++ b/modules/utils/docker/bridge_settings.sh
@@ -50,6 +50,11 @@ if [ -f "$COMMS_PCB_VERSION_FILE" ]; then
 fi
 echo $eth_port
 
+# Set mtu back to 1500 to support e2e connectivity
+# TODO: Investigate this as it should still work with 1460
+ifconfig bat0 mtu 1500
+ifconfig br-lan mtu 1500
+
 brctl addif br-lan bat0 $eth_port
 echo $br_lan_ip
 ifconfig br-lan $br_lan_ip netmask "255.255.255.0"

--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -350,7 +350,7 @@ elif [ "$mode" = "ap+mesh_mcc" ]; then
   echo "bindaddr = "\"$gw_ip\"";" >> /etc/umurmur.conf
   sleep 10
   umurmurd
-  elif [ "$mode" == "ap+mesh_scc" ]; then
+elif [ "$mode" == "ap+mesh_scc" ]; then
     sleep 2
     # chanbw config
     mount -t debugfs none /sys/kernel/debug

--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -85,11 +85,18 @@ if [ "$algo" = "olsr" ]; then
       iptables -A FORWARD --in-interface "$mesh_if" -j ACCEPT
       killall olsrd 2>/dev/null
       (olsrd -i br-lan -d 0)&
+      ifconfig "$mesh_if" mtu 1500
 else
       ##batman-adv###
       brctl addif br-lan bat0 "$ifname_ap"
       iptables -A FORWARD --in-interface bat0 -j ACCEPT
+      ifconfig bat0 mtu 1500
 fi
+
+# Set mtu back to 1500 to support e2e connectivity
+# TODO: Investigate this as it should still work with 1460
+ifconfig br-lan mtu 1500
+
 ifconfig br-lan "$br_lan_ip" netmask "255.255.255.0"
 ifconfig br-lan up
 echo


### PR DESCRIPTION
Set bat0 and br-lan MTUs to 1500 rather than 1460. This fixes end to end connectivity between connected devices (e.g., laptops/phones) on the AP or eth bridge (using 1460 only allows laptop->csl->csl.....).