### PR TITLE
Python packages updates

### DIFF
--- a/.github/workflows/tii-mesh-com.yaml
+++ b/.github/workflows/tii-mesh-com.yaml
@@ -1,5 +1,9 @@
 name: tii-mesh-com
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches: [ main, develop ]

--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -152,20 +152,11 @@ install_packages()
 mesh_service()
 {
   #start mesh service if mesh provisioning is done
-  hw_platform=$(grep Model /proc/cpuinfo| awk '{print $5}')
-  if [ "$hw_platform" == "Compute" ]; then
-    if [ -f "/opt/S9011sMesh" ]; then
-      #start Mesh service
-      echo "starting 11s mesh service"
-      /opt/S9011sMesh start
-      sleep 2
-    fi
-  else
-    if [ -f "/opt/S90mesh" ]; then
-      echo "starting ibss mesh service"
-      /opt/S90mesh start
-      sleep 2
-    fi
+  if [ -f "/opt/S9011sMesh" ]; then
+    #start Mesh service
+    echo "starting 11s mesh service"
+    /opt/S9011sMesh start
+    sleep 2
   fi
 }
 

--- a/modules/utils/package/README.md
+++ b/modules/utils/package/README.md
@@ -32,7 +32,6 @@ REL V1: Packages available in the bundle
 |matplotlib| 3.5.2     | machine_learning_packages |
 |packaging| 21.3      | machine_learning_packages |
 |pyparsing| 3.0.9     | machine_learning_packages |
-|sklearn| 0         | machine_learning_packages |
 |threadpoolctl| 3.1.0     | machine_learning_packages |
 |pypcap|           | machine_learning_packages |
 |setuptools| 65.5.1    | machine_learning_packages |

--- a/modules/utils/package/README.md
+++ b/modules/utils/package/README.md
@@ -1,38 +1,39 @@
 REL V1: Packages available in the bundle
 
-|Package         | Version    |    Location|
-|:----|:-----------|:----|
-|pandas| 1.4.2      | python_packages |
-|certifi| 2021.5.30  | python_packages     |
-|charset-normalizer| 2.0.7      |    python_packages|
-|idna| 3.2        |python_packages|
-|numpy| 1.22.3     |    python_packages|
-|Pillow| 9.1.1      |    python_packages|
-|python-dateutil|      2.8.2 | python_packages        |
-|pytz| 2022.1     |    python_packages|
-|requests| 2.26.0     |    python_packages|
-|six| 1.16.0     |    python_packages|
-|typing_extensions| 4.2.0      |    python_packages|
-|urllib3| 1.26.7     |    python_packages|
-|pbkdf| 2-1.3      |    python_packages|
-|wifi| 0.3.8      |    python_packages|
-|cryptography| 39.0.0     |    python_packages|
-|scitools_pyke| 1.1.1      |    python_packages|
-|torchaudio| 0.11.0     |    machine_learning2|
-|torchvision| 0.12.0     |    machine_learning2|
-|scikit-learn| 1.1.1      |    machine_learning2|
-|scipy| 1.8.1      |    machine_learning2|
-|xgboost| 1.6.1      |    machine_learning2|
-|torch| 1.11.0     |    machine_learning_packages|
-|dpkt| 1.9.7.2    |    machine_learning_packages|
-|cycler| 0.11.0     |    machine_learning_packages|
-|fonttools| 4.33.3     |    machine_learning_packages|
-|joblib| 1.1.0      | machine_learning_packages |
-|kiwisolver| 1.4.3      | machine_learning_packages |
-|matplotlib| 3.5.2      | machine_learning_packages |
-|packaging| 21.3       | machine_learning_packages |
-|pyparsing| 3.0.9      | machine_learning_packages |
-|sklearn| 0          | machine_learning_packages |
-|threadpoolctl| 3.1.0      | machine_learning_packages |
-|pypcap|            | machine_learning_packages |
+|Package         | Version   |    Location|
+|:----|:----------|:----|
+|pandas| 1.4.2     | python_packages |
+|certifi| 2022.12.7 | python_packages     |
+|charset-normalizer| 2.0.7     |    python_packages|
+|idna| 3.2       |python_packages|
+|numpy| 1.22.3    |    python_packages|
+|Pillow| 9.3.0     |    python_packages|
+|python-dateutil| 2.8.2     | python_packages        |
+|pytz| 2022.1    |    python_packages|
+|requests| 2.26.0    |    python_packages|
+|six| 1.16.0    |    python_packages|
+|typing_extensions| 4.2.0     |    python_packages|
+|urllib3| 1.26.7    |    python_packages|
+|pbkdf| 2-1.3     |    python_packages|
+|wifi| 0.3.8     |    python_packages|
+|cryptography| 39.0.1    |    python_packages|
+|scitools_pyke| 1.1.1     |    python_packages|
+|torchaudio| 0.11.0    |    machine_learning2|
+|torchvision| 0.12.0    |    machine_learning2|
+|scikit-learn| 1.1.1     |    machine_learning2|
+|scipy| 1.10.1    |    machine_learning2|
+|xgboost| 1.7.0     |    machine_learning2|
+|torch| 1.13.1    |    machine_learning_packages|
+|dpkt| 1.9.7.2   |    machine_learning_packages|
+|cycler| 0.11.0    |    machine_learning_packages|
+|fonttools| 4.33.3    |    machine_learning_packages|
+|joblib| 1.2.0     | machine_learning_packages |
+|kiwisolver| 1.4.3     | machine_learning_packages |
+|matplotlib| 3.5.2     | machine_learning_packages |
+|packaging| 21.3      | machine_learning_packages |
+|pyparsing| 3.0.9     | machine_learning_packages |
+|sklearn| 0         | machine_learning_packages |
+|threadpoolctl| 3.1.0     | machine_learning_packages |
+|pypcap|           | machine_learning_packages |
+|setuptools| 65.5.1    | machine_learning_packages |
 


### PR DESCRIPTION
Updated the following python packages in modules/utils/package/:
* certifi --> v 2022.5.18.1 to 2022.12.7
* Pillow --> v 9.1.1 to 9.3.0
* cryptography --> v 39.0.0 to 39.0.1
* xgboost --> v 1.6.1 to 1.7.0
* scipy --> v 1.8.1 to 1.10.1
* torch --> v 1.11.0 to 1.13.1
* joblib --> v 1.1.0 to 1.2.0
* setuptools --> v 62.6.0 to 65.5.1

modules/sc-mesh-secure-deployment/src/1_5/main.py is running fine for MS 1.5