### PR TITLE
mesh_com: remove CM4 platform check for mesh service to be started in multiple platforms(CM4, saplukiPI ..)

### DIFF
--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -152,20 +152,11 @@ install_packages()
 mesh_service()
 {
   #start mesh service if mesh provisioning is done
-  hw_platform=$(grep Model /proc/cpuinfo| awk '{print $5}')
-  if [ "$hw_platform" == "Compute" ]; then
-    if [ -f "/opt/S9011sMesh" ]; then
-      #start Mesh service
-      echo "starting 11s mesh service"
-      /opt/S9011sMesh start
-      sleep 2
-    fi
-  else
-    if [ -f "/opt/S90mesh" ]; then
-      echo "starting ibss mesh service"
-      /opt/S90mesh start
-      sleep 2
-    fi
+  if [ -f "/opt/S9011sMesh" ]; then
+    #start Mesh service
+    echo "starting 11s mesh service"
+    /opt/S9011sMesh start
+    sleep 2
   fi
 }
 


### PR DESCRIPTION
1) Remove platform check to start the mesh mode to support multiple platforms. S9011sMesh service has already the supported radio check based on PCI device ID. 
2) Remove deprecated ibss mesh mode service start.