### PR TITLE
Update new sensors to field_test_logger and other enhancements

### DIFF
--- a/common/tools/field_test_logger/S95logger
+++ b/common/tools/field_test_logger/S95logger
@@ -5,7 +5,7 @@ name="field_test_logger"
 # The path of the client executable
 command="/usr/bin/python3"
 # Any command line arguments for the client executable
-command_args="/usr/local/bin/field_test_logger.py $2"
+command_args="/usr/local/bin/field_test_logger.py -u $2"
 # The path of the daemon executable
 daemon="/usr/bin/daemon"
 

--- a/common/tools/field_test_logger/field_test_logger.py
+++ b/common/tools/field_test_logger/field_test_logger.py
@@ -115,13 +115,19 @@ if __name__ == '__main__':
         INTERFACE_ARG = args.interface
 
     if args.unique is None or args.unique == "":
-        UNIQUE_ARG = ""
+        UNIQUE_ARG = f"_{INTERFACE_ARG}_{BATMAN_ARG}"
     else:
-        UNIQUE_ARG = f"_{args.unique}"
+        UNIQUE_ARG = f"_{INTERFACE_ARG}_{BATMAN_ARG}_{args.unique}"
+
+    try:
+        with open("/etc/comms_pcb_version", "r") as file_r:
+            PCB_VERSION = file_r.read().strip().split("=")[1]
+    except FileNotFoundError:
+        PCB_VERSION = "unknown"
 
     ftl = FieldTestLogger()
     wifi_stats = wifi_info.WifiInfo(LOGGING_INTERVAL_SECONDS, INTERFACE_ARG, BATMAN_ARG)
-    info = infoparser.InfoParser()
+    info = infoparser.InfoParser(PCB_VERSION)
 
     ftl.register_logger_function("Timestamp", timestamp)
     wifi_stats.update()
@@ -159,8 +165,6 @@ if __name__ == '__main__':
     ftl.register_logger_function("3V3 mpcie5 current [mA]", info.get_mpcie5_current)
     ftl.register_logger_function("3V3 mpcie7 voltage [mV]", info.get_mpcie7_voltage)
     ftl.register_logger_function("3V3 mpcie7 current [mA]", info.get_mpcie7_current)
-    ftl.register_logger_function("nrf2 voltage [mV]", info.get_nrf2_voltage)
-    ftl.register_logger_function("nrf2 current [mA]", info.get_nrf2_current)
 
     ftl.register_logger_function("bme280 rel. humidity [m%]", info.get_humidity)
     ftl.register_logger_function("bme280 pressure [kPa]", info.get_pressure)

--- a/common/tools/field_test_logger/infoparser.py
+++ b/common/tools/field_test_logger/infoparser.py
@@ -1,11 +1,17 @@
+"""
+InfoParser class is used to parse the information from the system and GPSD.
+"""
 import glob
 import gpsd
 
 
 def read_value(file: str) -> str:
+    """
+    Read a single value from a file.
+    """
     try:
-        with open(file, 'r') as f:
-            value = f.readline()
+        with open(file, 'r') as file_handle:
+            value = file_handle.readline()
 
             return value.strip()
 
@@ -14,28 +20,38 @@ def read_value(file: str) -> str:
 
 
 def get_hwmon_path_from_options(paths: [str]) -> str:
+    """
+    Get the path to the hwmon directory.
+    """
     for path in paths:
-        p = get_hwmon_path(path)
-        if p != "NaN":
-            return p
+        path_to_validate = get_hwmon_path(path)
+        if path_to_validate != "NaN":
+            return path_to_validate
     return "NaN"
 
 
 def get_hwmon_path(path: str) -> str:
+    """
+    Get the path to the hwmon directory.
+    """
     # hwmon directory should contain only one entry which is of format hwmon*
     try:
         return glob.glob(path)[0]
     except:
         return "NaN"
 
-
-# ----------------------------------------
-
-
+#pylint: disable=too-many-instance-attributes, too-many-public-methods
 class InfoParser:
+    """
+    InfoParser class is used to parse the information from the system and GPSD.
+    """
 
     def __init__(self):
-        self.__gpsdConnected = False
+        """
+        Initialize the InfoParser class.
+        """
+        self.__gpsd_connected = False
+        self.__max17260_connected = True
         #
         self.__altitude = 0
         self.__latitude = -999999
@@ -47,6 +63,7 @@ class InfoParser:
         self.__track = 0
         #
         self.__cpu_temp = "NaN"
+        self.__bat_temp = "NaN"
         self.__wifi_temp = "NaN"
         self.__tmp100 = "NaN"
         #
@@ -59,97 +76,282 @@ class InfoParser:
         self.__voltage_3v3 = "NaN"
         self.__current_dc = "NaN"
         self.__voltage_dc = "NaN"
+        #
+        self.__current_mpcie3 = "NaN"
+        self.__voltage_mpcie3 = "NaN"
+        self.__current_mpcie5 = "NaN"
+        self.__voltage_mpcie5 = "NaN"
+        self.__current_mpcie7 = "NaN"
+        self.__voltage_mpcie7 = "NaN"
+        self.__current_nrf2 = "NaN"
+        self.__voltage_nrf2 = "NaN"
+        #
+        self.__humidity = "NaN"
+        self.__pressure = "NaN"
+        self.__temperature = "NaN"
 
     # ----------------------------------------
 
     def get_altitude(self) -> str:
+        """
+        Get altitude
+        """
         return str(self.__altitude)
 
     def get_latitude(self) -> str:
+        """
+        Get latitude
+        """
         return str(self.__latitude)
 
     def get_longitude(self) -> str:
+        """
+        Get longitude
+        """
         return str(self.__longitude)
 
     def get_gps_time(self) -> str:
+        """
+        Get GPS time
+        """
         return self.__gps_time
 
     def get_pdop(self) -> str:
+        """
+        Get pdop
+        """
         return str(self.__pdop)
 
     def get_speed(self) -> str:
+        """
+        Get speed
+        """
         return str(self.__speed)
 
     def get_climb(self) -> str:
+        """
+        Get climb
+        """
         return str(self.__climb)
 
     def get_track(self) -> str:
+        """
+        Get track
+        """
         return str(self.__track)
 
     def get_cpu_temp(self):
+        """
+        Get CPU temperature
+        """
         return self.__cpu_temp
 
     def get_bat_temp(self):
+        """
+        Get battery temperature
+        """
         return self.__bat_temp
 
     def get_tmp100(self):
+        """
+        Get TMP100 temperature
+        """
         return self.__tmp100
 
     def get_wifi_temp(self):
+        """
+        Get wifi temperature
+        """
         return self.__wifi_temp
 
     def get_battery_voltage(self):
+        """
+        Get battery voltage
+        """
         return self.__battery_voltage
 
     def get_battery_current(self):
+        """
+        Get battery current
+        """
         return self.__battery_current
 
     def get_nrf_current(self):
+        """
+        Get NRF current
+        """
         return self.__current_nrf
 
     def get_nrf_voltage(self):
+        """
+        Get NRF voltage
+        """
         return self.__voltage_nrf
 
     def get_3v3_current(self):
+        """
+        Get 3V3 current
+        """
         return self.__current_3v3
 
     def get_3v3_voltage(self):
+        """
+        Get 3V3 voltage
+        """
         return self.__voltage_3v3
 
     def get_dc_current(self):
+        """
+        Get DC current
+        """
         return self.__current_dc
 
     def get_dc_voltage(self):
+        """
+        Get DC voltage
+        """
         return self.__voltage_dc
+
+    def get_mpcie3_current(self):
+        """
+        Get mPCIe3 current
+        """
+        return self.__current_mpcie3
+
+    def get_mpcie3_voltage(self):
+        """
+        Get mPCIe3 voltage
+        """
+        return self.__voltage_mpcie3
+
+    def get_mpcie5_current(self):
+        """
+        Get mPCIe5 current
+        """
+        return self.__current_mpcie5
+
+    def get_mpcie5_voltage(self):
+        """
+        Get mPCIe5 voltage
+        """
+        return self.__voltage_mpcie5
+
+    def get_mpcie7_current(self):
+        """
+        Get mPCIe7 current
+        """
+        return self.__current_mpcie7
+
+    def get_mpcie7_voltage(self):
+        """
+        Get mPCIe7 voltage
+        """
+        return self.__voltage_mpcie7
+
+    def get_nrf2_current(self):
+        """
+        Get NRF2 current
+        """
+        return self.__current_nrf2
+
+    def get_nrf2_voltage(self):
+        """
+        Get NRF2 voltage
+        """
+        return self.__voltage_nrf2
+
+    def get_humidity(self):
+        """
+        Get humidity
+        """
+        return self.__humidity
+
+    def get_pressure(self):
+        """
+        Get pressure
+        """
+        return self.__pressure
+
+    def get_temperature(self):
+        """
+        Get temperature
+        """
+        return self.__temperature
 
     # ----------------------------------------
 
     def __update_battery_status(self):
-        self.__battery_voltage = read_value("/sys/class/power_supply/max1726x_battery/voltage_now")
-        self.__battery_current = read_value("/sys/class/power_supply/max1726x_battery/current_now")
+        """
+        Update battery status
+        """
+        if self.__max17260_connected:
+            # check if max17260 is connected and if not, set all values to NaN and
+            # don't try to check anymore ( causing a lot of errors in the dmesg log )
+            if read_value("/sys/class/power_supply/max1726x_battery/uevent") == "":
+                self.__battery_voltage = "NaN"
+                self.__battery_current = "NaN"
+                self.__max17260_connected = False
+                return
 
-    def __get_cpu_load(self) -> str:
-        load = read_value("/proc/loadavg")
-        return load.split()[0]
+            self.__battery_voltage = read_value(
+                get_hwmon_path("/sys/class/power_supply/max1726x_battery/voltage_now"))
+            self.__battery_current = read_value(
+                get_hwmon_path("/sys/class/power_supply/max1726x_battery/current_now"))
+
+    # @staticmethod
+    # def __get_cpu_load() -> str:
+    #     """
+    #     Get CPU load
+    #     """
+    #     load = read_value("/proc/loadavg")
+    #     return load.split()[0]
+
+    def __update_bme280_status(self):
+        """
+        Update BME280 status
+        """
+        self.__humidity = read_value(
+            get_hwmon_path("/sys/bus/iio/devices/iio:device*/in_humidityrelative_input"))
+        self.__pressure = read_value(
+            get_hwmon_path("/sys/bus/iio/devices/iio:device*/in_pressure_input"))
+        self.__temperature = read_value(
+            get_hwmon_path("/sys/bus/iio/devices/iio:device*/in_temp_input"))
+
+    def __update_ina231_status(self):
+        """
+        Update INA231 status
+        """
+        self.__current_mpcie3 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0046/hwmon/hwmon*/curr1_input"))
+        self.__voltage_mpcie3 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0046/hwmon/hwmon*/in1_input"))
+        self.__current_mpcie5 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/curr1_input"))
+        self.__voltage_mpcie5 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/in1_input"))
+        self.__current_mpcie7 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/curr1_input"))
+        self.__voltage_mpcie7 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/in1_input"))
+        self.__current_nrf2 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0044/hwmon/hwmon*/curr1_input"))
+        self.__voltage_nrf2 = read_value(
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0044/hwmon/hwmon*/in1_input"))
 
     def __update_ina2xx_status(self):
+        """
+        Update INA2xx status
+        """
         self.__current_nrf = read_value(
-            get_hwmon_path_from_options(
-                ["/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/curr1_input",
-                 "/sys/class/i2c-adapter/i2c-10/10-0040/hwmon/hwmon*/curr1_input"]))
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/curr1_input"))
         self.__voltage_nrf = read_value(
-            get_hwmon_path_from_options(
-                ["/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/in1_input",
-                 "/sys/class/i2c-adapter/i2c-10/10-0040/hwmon/hwmon*/in1_input"]))
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/in1_input"))
 
         self.__current_3v3 = read_value(
-            get_hwmon_path_from_options(
-                ["/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/curr1_input",
-                 "/sys/class/i2c-adapter/i2c-10/10-0045/hwmon/hwmon*/curr1_input"]))
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/curr1_input"))
+
         self.__voltage_3v3 = read_value(
-            get_hwmon_path_from_options(
-                ["/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/in1_input",
-                 "/sys/class/i2c-adapter/i2c-10/10-0045/hwmon/hwmon*/in1_input"]))
+            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/in1_input"))
 
         self.__current_dc = read_value(
             get_hwmon_path("/sys/class/i2c-adapter/i2c-0/0-0041/hwmon/hwmon*/curr1_input"))
@@ -158,6 +360,9 @@ class InfoParser:
             get_hwmon_path("/sys/class/i2c-adapter/i2c-0/0-0041/hwmon/hwmon*/in1_input"))
 
     def __update_temperatures(self):
+        """
+        Update temperatures
+        """
         self.__cpu_temp = read_value("/sys/class/thermal/thermal_zone0/temp")
         self.__bat_temp = read_value("/sys/class/thermal/thermal_zone1/temp")
         self.__tmp100 = read_value(
@@ -168,9 +373,12 @@ class InfoParser:
             get_hwmon_path("/sys/class/ieee80211/phy0/device/hwmon/hwmon*/temp1_input"))
 
     def __update_gpsd_data(self):
-        if not self.__gpsdConnected:
+        """
+        Update GPSD data
+        """
+        if not self.__gpsd_connected:
             gpsd.connect()
-            self.__gpsdConnected = True
+            self.__gpsd_connected = True
 
         try:
             gps_response = gpsd.get_current()
@@ -202,6 +410,8 @@ class InfoParser:
         self.__update_temperatures()
         self.__update_battery_status()
         self.__update_ina2xx_status()
+        self.__update_ina231_status()
+        self.__update_bme280_status()
         # print(f"lat: {self.latitude}")
         # print(f"lon: {self.longitude}")
         # print(f"alt: {self.altitude}")

--- a/common/tools/field_test_logger/infoparser.py
+++ b/common/tools/field_test_logger/infoparser.py
@@ -46,10 +46,12 @@ class InfoParser:
     InfoParser class is used to parse the information from the system and GPSD.
     """
 
-    def __init__(self):
+    def __init__(self, pcb_version: str):
         """
         Initialize the InfoParser class.
         """
+        self.__pcb_version = pcb_version
+        #
         self.__gpsd_connected = False
         self.__max17260_connected = True
         #
@@ -83,8 +85,6 @@ class InfoParser:
         self.__voltage_mpcie5 = "NaN"
         self.__current_mpcie7 = "NaN"
         self.__voltage_mpcie7 = "NaN"
-        self.__current_nrf2 = "NaN"
-        self.__voltage_nrf2 = "NaN"
         #
         self.__humidity = "NaN"
         self.__pressure = "NaN"
@@ -248,18 +248,6 @@ class InfoParser:
         """
         return self.__voltage_mpcie7
 
-    def get_nrf2_current(self):
-        """
-        Get NRF2 current
-        """
-        return self.__current_nrf2
-
-    def get_nrf2_voltage(self):
-        """
-        Get NRF2 voltage
-        """
-        return self.__voltage_nrf2
-
     def get_humidity(self):
         """
         Get humidity
@@ -321,43 +309,47 @@ class InfoParser:
         """
         Update INA231 status
         """
-        self.__current_mpcie3 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0046/hwmon/hwmon*/curr1_input"))
-        self.__voltage_mpcie3 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0046/hwmon/hwmon*/in1_input"))
-        self.__current_mpcie5 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/curr1_input"))
-        self.__voltage_mpcie5 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/in1_input"))
-        self.__current_mpcie7 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/curr1_input"))
-        self.__voltage_mpcie7 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/in1_input"))
-        self.__current_nrf2 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0044/hwmon/hwmon*/curr1_input"))
-        self.__voltage_nrf2 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0044/hwmon/hwmon*/in1_input"))
+        if self.__pcb_version == "1":
+            self.__current_mpcie3 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0046/hwmon/hwmon*/curr1_input"))
+            self.__voltage_mpcie3 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0046/hwmon/hwmon*/in1_input"))
+            self.__current_mpcie5 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/curr1_input"))
+            self.__voltage_mpcie5 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/in1_input"))
+            self.__current_mpcie7 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/curr1_input"))
+            self.__voltage_mpcie7 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/in1_input"))
+            self.__current_nrf = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0044/hwmon/hwmon*/curr1_input"))
+            self.__voltage_nrf = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0044/hwmon/hwmon*/in1_input"))
 
     def __update_ina2xx_status(self):
         """
         Update INA2xx status
         """
-        self.__current_nrf = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/curr1_input"))
-        self.__voltage_nrf = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/in1_input"))
+        if self.__pcb_version != "1":
+            self.__current_nrf = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/curr1_input"))
+            self.__voltage_nrf = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0040/hwmon/hwmon*/in1_input"))
 
-        self.__current_3v3 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/curr1_input"))
-
-        self.__voltage_3v3 = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/in1_input"))
+            self.__current_3v3 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/curr1_input"))
+            self.__voltage_3v3 = read_value(
+                get_hwmon_path("/sys/class/i2c-adapter/i2c-1/1-0045/hwmon/hwmon*/in1_input"))
 
         self.__current_dc = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-0/0-0041/hwmon/hwmon*/curr1_input"))
-
+            get_hwmon_path_from_options(
+                ["/sys/class/i2c-adapter/i2c-0/0-0041/hwmon/hwmon*/curr1_input",
+                "/sys/class/i2c-adapter/i2c-1/1-0041/hwmon/hwmon*/curr1_input"]))
         self.__voltage_dc = read_value(
-            get_hwmon_path("/sys/class/i2c-adapter/i2c-0/0-0041/hwmon/hwmon*/in1_input"))
+            get_hwmon_path_from_options(
+                ["/sys/class/i2c-adapter/i2c-0/0-0041/hwmon/hwmon*/in1_input",
+                "/sys/class/i2c-adapter/i2c-1/1-0041/hwmon/hwmon*/in1_input"]))
 
     def __update_temperatures(self):
         """


### PR DESCRIPTION
Update new sensors to field_test_logger and other enhancements
    
- New sensors added
- Arguments handling refactored and new arguments added:
  -u = suffix to the log file name (default: "")
  -i = network interface used in logging (default: wlp1s0)
  -b = batman interface used in logging (default: bat0)
    
- error handling added, if max17260 not connected.  This flooded system log with HW without the max-chip.