### PR TITLE
QoS OLSR v2

### DIFF
--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -152,20 +152,11 @@ install_packages()
 mesh_service()
 {
   #start mesh service if mesh provisioning is done
-  hw_platform=$(grep Model /proc/cpuinfo| awk '{print $5}')
-  if [ "$hw_platform" == "Compute" ]; then
-    if [ -f "/opt/S9011sMesh" ]; then
-      #start Mesh service
-      echo "starting 11s mesh service"
-      /opt/S9011sMesh start
-      sleep 2
-    fi
-  else
-    if [ -f "/opt/S90mesh" ]; then
-      echo "starting ibss mesh service"
-      /opt/S90mesh start
-      sleep 2
-    fi
+  if [ -f "/opt/S9011sMesh" ]; then
+    #start Mesh service
+    echo "starting 11s mesh service"
+    /opt/S9011sMesh start
+    sleep 2
   fi
 }
 

--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -196,96 +196,6 @@ psk="ssrcdemo"
 EOF
 }
 
-#write in the dhcpd.conf and the olsrd.conf add the ipv4 subnet and the random ipv6
-create_dhcpd_config()
-{
-  SUBNET="$1"
-
-  cat > /etc/dhcp/dhcpd.conf <<- EOF
-    default-lease-time 600;
-    max-lease-time 7200;
-    ddns-update-style none;
-    authoritative;
-
-    subnet $SUBNET.0 netmask 255.255.255.0 {
-            range $SUBNET.100 $SUBNET.199;
-            option routers $SUBNET.1;
-    }
-EOF
-  cp /dev/null /var/lib/dhcp/dhcpd.leases
-}
-
-create_olsrd_config()
-{
-  wifidev="$1"
-  SUBNET="$2"
-  IPV6_PREFIX="$3"
-
-  cat > /etc/olsrd/olsrd.conf <<- EOF
-  
-  LinkQualityFishEye   0
-
-  Interface "$wifidev"
-
-  {
-
-  }
-
-  IpVersion               4
-
-  LinkQualityFishEye      0
-
-  LinkQualityAlgorithm "etx_ffeth_nl80211"
-
-  # This is only here to be able to generate a
-
-  # configuration file with the script
-
-  #LoadPlugin "/usr/lib/olsrd_jsoninfo.so.1.1"
-
-  #{
-
-    #PlParam "port"          "9090"
-
-    #PlParam "accept"        "0.0.0.0"
-
-  #}
-
-  # load arprefresh plugin
-
-  # - UDP packets on port 698
-
-  LoadPlugin "/usr/lib/olsrd_arprefresh.so.0.1"  
-
-  {
-
-  }
-
-  Hna4
-  {
-          $SUBNET.0 255.255.255.0
-  }
-
-  Hna6
-  {
-          $IPV6_PREFIX:0 64
-  }
-EOF
-}
-
-create_radvd_config()
-{
-  IPV6_PREFIX="$1"
-
-  cat > /etc/radvd.conf <<- EOF
-    interface br-lan
-    {
-            AdvSendAdvert on;
-            prefix $IPV6_PREFIX:0/64 {
-            };
-    };
-EOF
-}
 
 generate_random_mesh_ip() {
   local last_oct=$((16#$1))
@@ -460,20 +370,7 @@ elif [ "$mode" == "ap+mesh_scc" ]; then
     iw dev "$mesh_if" interface add "$ifname_ap" type managed addr "00:01:$(echo "$pcie_radio_mac" | cut -b 7-17)"
 
     # Set frequency band and channel from given frequency
-    calculate_wifi_channel "$ch"
-
-    #random generate the ipv6
-    IPV6_PREFIX=$( echo fd`dd if=/dev/urandom bs=7 count=1 status=none | xxd -p` | sed 's/\(....\)/\1:/g' )
-    ip addr add $SUBNET.1/24 dev br-lan && ip addr add $IPV6_PREFIX:1/64 dev br-lan
-
-    create_olsrd_config "wlp1s0" "$SUBNET" "$IPV6_PREFIX"
-    # FIXME: launch olsrd
-
-    create_dhcpd_config "$SUBNET"
-    dhcpd -f br-lan
-
-    create_radvd_config "$IPV6_PREFIX"
-    # FIXME: launch radvd
+     calculate_wifi_channel "$ch"
 
   # AP hostapd config
   cat <<EOF >/var/run/hostapd.conf

--- a/modules/utils/docker/entrypoint.sh
+++ b/modules/utils/docker/entrypoint.sh
@@ -152,11 +152,20 @@ install_packages()
 mesh_service()
 {
   #start mesh service if mesh provisioning is done
-  if [ -f "/opt/S9011sMesh" ]; then
-    #start Mesh service
-    echo "starting 11s mesh service"
-    /opt/S9011sMesh start
-    sleep 2
+  hw_platform=$(grep Model /proc/cpuinfo| awk '{print $5}')
+  if [ "$hw_platform" == "Compute" ]; then
+    if [ -f "/opt/S9011sMesh" ]; then
+      #start Mesh service
+      echo "starting 11s mesh service"
+      /opt/S9011sMesh start
+      sleep 2
+    fi
+  else
+    if [ -f "/opt/S90mesh" ]; then
+      echo "starting ibss mesh service"
+      /opt/S90mesh start
+      sleep 2
+    fi
   fi
 }
 
@@ -241,15 +250,15 @@ create_olsrd_config()
 
   # configuration file with the script
 
-  LoadPlugin "/usr/lib/olsrd_jsoninfo.so.1.1"
+  #LoadPlugin "/usr/lib/olsrd_jsoninfo.so.1.1"
 
-  {
+  #{
 
-    PlParam "port"          "9090"
+    #PlParam "port"          "9090"
 
-    PlParam "accept"        "0.0.0.0"
+    #PlParam "accept"        "0.0.0.0"
 
-  }
+  #}
 
   # load arprefresh plugin
 

--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -188,10 +188,8 @@ if [ "$algo" = "olsr" ]; then
   dhcpd -f br-lan
   create_radvd_config "$IPV6_PREFIX"
 # FIXME: launch radvd
-  mesh_if_mac="$(ip -brief link | grep "$mesh_if" | awk '{print $3; exit}')"
-  ip_random="$(echo "$mesh_if_mac" | cut -b 16-17)"
-  br_lan_ip="$SUBNET."$((16#$ip_random))
-  ifname_ap="$(ifconfig -a | grep "wlan*" | awk -F':' '{ print $1 }')"	
+  
+  br_lan_ip="$SUBNET."$((16#$ip_random))	
   wlp1s0_ip="192.168.11."$((16#$ip_random))
   ifconfig wlp1s0 "$wlp1s0_ip" 
   brctl addif br-lan "$ifname_ap"

--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -26,7 +26,7 @@ configure
 ###Deciding IP address to be assigned to br-lan from WiFi MAC
 mesh_if_mac="$(ip -brief link | grep "$mesh_if" | awk '{print $3; exit}')"
 ip_random="$(echo "$mesh_if_mac" | cut -b 16-17)"
-br_lan_ip="192.168.$SUBNET."$((16#$ip_random))
+br_lan_ip="$SUBNET."$((16#$ip_random))
 ifname_ap="$(ifconfig -a | grep "wlan*" | awk -F':' '{ print $1 }')"
 wlp1s0_ip="192.168.11."$((16#$ip_random))
 ifconfig wlp1s0 "$wlp1s0_ip" 

--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -184,20 +184,20 @@ create_radvd_config "$IPV6_PREFIX"
 # FIXME: launch radvd
 
 # AP hostapd config
-cat > /var/run/hostapd.conf <<- EOF
-  country_code=AE
-  interface=$ifname_ap
-  ssid=$ssid
-  hw_mode=g
-  channel=$retval_channel
-  macaddr_acl=0
-  auth_algs=1
-  ignore_broadcast_ssid=0
-  wpa=2
-  wpa_passphrase=ssrcdemo
-  wpa_key_mgmt=WPA-PSK
-  wpa_pairwise=TKIP
-  rsn_pairwise=CCMP
+cat <<EOF >/var/run/hostapd.conf
+country_code=AE
+interface=$ifname_ap
+ssid=$ssid
+hw_mode=$retval_band
+channel=$retval_channel
+macaddr_acl=0
+auth_algs=1
+ignore_broadcast_ssid=0
+wpa=2
+wpa_passphrase=ssrcdemo
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=TKIP
+rsn_pairwise=CCMP
 EOF
 
 # Start AP

--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -26,9 +26,10 @@ configure
 ###Deciding IP address to be assigned to br-lan from WiFi MAC
 mesh_if_mac="$(ip -brief link | grep "$mesh_if" | awk '{print $3; exit}')"
 ip_random="$(echo "$mesh_if_mac" | cut -b 16-17)"
-br_lan_ip="192.168.1."$((16#$ip_random))
+br_lan_ip="192.168.3."$((16#$ip_random))
 ifname_ap="$(ifconfig -a | grep "wlan*" | awk -F':' '{ print $1 }')"
-
+wlp1s0_ip="192.168.11."$((16#$ip_random))
+ifconfig wlp1s0 "$wlp1s0_ip" 
 
 calculate_wifi_channel()
 {
@@ -50,47 +51,169 @@ calculate_wifi_channel()
 }
 
 
+
+create_ap_config()
+{
+  cat > ap.conf <<- EOF
+    network={
+      ssid="WirelessLab"
+      psk="ssrcdemo"
+    }
+  EOF
+}
+
+
+
+create_dhcpd_config()
+{
+  SUBNET="$1"
+
+  cat > /etc/dhcp/dhcpd.conf <<- EOF
+    default-lease-time 600;
+    max-lease-time 7200;
+    ddns-update-style none;
+    authoritative;
+
+    subnet $SUBNET.0 netmask 255.255.255.0 {
+            range $SUBNET.100 $SUBNET.199;
+            option routers $SUBNET.1;
+    }
+  EOF
+  cp /dev/null /var/lib/dhcp/dhcpd.leases
+}
+
+
+
+create_olsrd_config()
+{
+  wifidev="$1"
+  SUBNET="$2"
+  IPV6_PREFIX="$3"
+
+  cat > /etc/olsrd/olsrd.conf <<- EOF
+  
+  LinkQualityFishEye 	0
+
+  Interface "$wifidev"
+
+  {
+
+  }
+
+ 
+
+  IpVersion               4
+
+  #LinkQualityFishEye      0
+
+  LinkQualityAlgorithm "etx_ffeth_nl80211"
+
+ 
+
+  # This is only here to be able to generate a
+
+  # configuration file with the script
+
+  #LoadPlugin "/usr/lib/olsrd_jsoninfo.so.1.1"
+
+
+  # load arprefresh plugin
+
+  # - UDP packets on port 698
+
+  LoadPlugin "/usr/lib/olsrd_arprefresh.so.0.1"  
+
+  {
+
+  }
+
+  Hna4
+  {
+          $SUBNET.0 255.255.255.0
+  }
+
+  Hna6
+  {
+          $IPV6_PREFIX:0 64
+  }
+  EOF
+}
+
+
+
+create_radvd_config()
+{
+  IPV6_PREFIX="$1"
+
+  cat > /etc/radvd.conf <<- EOF
+    interface br-lan
+    {
+            AdvSendAdvert on;
+            prefix $IPV6_PREFIX:0/64 {
+            };
+    };
+  EOF
+}
+
+
+
+
+
+
 # mcc_settings
 echo "Running mcc_settings"
 # Create bridge br-lan
 brctl addbr br-lan
+ifname_ap="$(ifconfig -a | grep -E '^wlan' -m 1 | awk -F':' '{ print $1 }')"
 ap_if_mac="$(ip -brief link | grep "$ifname_ap" | awk '{print $3; exit}')"
 ssid="comms_sleeve#$(echo "$ap_if_mac" | cut -b 13-14,16-17)"
 # Set frequency band and channel from given frequency
 calculate_wifi_channel "$ch"
-ifconfig "$ifname_ap" up
+ifconfig $ifname_ap up
+  
+IPV6_PREFIX=$( echo fd`dd if=/dev/urandom bs=7 count=1 status=none | xxd -p` | sed 's/\(....\)/\1:/g' )
+ip addr add $SUBNET.1/24 dev br-lan && ip addr add $IPV6_PREFIX:1/64 dev br-lan
+
+create_olsrd_config "wlp1s0" "$SUBNET" "$IPV6_PREFIX"
+# FIXME: launch olsrd
+
+create_dhcpd_config "$SUBNET"
+dhcpd -f br-lan
+
+create_radvd_config "$IPV6_PREFIX"
+# FIXME: launch radvd
 
 # AP hostapd config
-cat <<EOF >/var/run/hostapd.conf
-country_code=AE
-interface=$ifname_ap
-ssid=$ssid
-hw_mode=$retval_band
-channel=$retval_channel
-macaddr_acl=0
-auth_algs=1
-ignore_broadcast_ssid=0
-wpa=2
-wpa_passphrase=ssrcdemo
-wpa_key_mgmt=WPA-PSK
-wpa_pairwise=TKIP
-rsn_pairwise=CCMP
+cat > /var/run/hostapd.conf <<- EOF
+  country_code=AE
+  interface=$ifname_ap
+  ssid=$ssid
+  hw_mode=g
+  channel=$retval_channel
+  macaddr_acl=0
+  auth_algs=1
+  ignore_broadcast_ssid=0
+  wpa=2
+  wpa_passphrase=ssrcdemo
+  wpa_key_mgmt=WPA-PSK
+  wpa_pairwise=TKIP
+  rsn_pairwise=CCMP
 EOF
 
 # Start AP
 /usr/sbin/hostapd -B /var/run/hostapd.conf -f /tmp/hostapd.log
 # Bridge AP and Mesh
 if [ "$algo" = "olsr" ]; then
-      brctl addif br-lan "$mesh_if" "$ifname_ap"
-      iptables -A FORWARD --in-interface "$mesh_if" -j ACCEPT
-      killall olsrd 2>/dev/null
-      (olsrd -i br-lan -d 0)&
-      ifconfig "$mesh_if" mtu 1500
+  brctl addif br-lan "$ifname_ap"
+  iptables -A FORWARD --in-interface $mesh_if -j ACCEPT
+  killall olsrd 2>/dev/null	
+  (qos-olsrd -i wlp1s0 -d 0)&
+  ifconfig "$mesh_if" mtu 1500
 else
-      ##batman-adv###
-      brctl addif br-lan bat0 "$ifname_ap"
-      iptables -A FORWARD --in-interface bat0 -j ACCEPT
-      ifconfig bat0 mtu 1500
+  ##batman-adv###
+  brctl addif br-lan bat0 "$ifname_ap"
+  iptables -A FORWARD --in-interface bat0 -j ACCEPT
+  ifconfig bat0 mtu 1500
 fi
 
 # Set mtu back to 1500 to support e2e connectivity

--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -48,30 +48,20 @@ calculate_wifi_channel()
     fi
 }
 
-create_ap_config()
-{
-cat <<EOF > ap.conf
-network={
-ssid="WirelessLab"
-psk="ssrcdemo"
-}
-EOF
-}
-
 create_dhcpd_config()
 {
   SUBNET="$1"
 
   cat > /etc/dhcp/dhcpd.conf <<- EOF
-    default-lease-time 600;
-    max-lease-time 7200;
-    ddns-update-style none;
-    authoritative;
+  default-lease-time 600;
+  max-lease-time 7200;
+  ddns-update-style none;
+  authoritative;
 
-    subnet $SUBNET.0 netmask 255.255.255.0 {
-            range $SUBNET.100 $SUBNET.199;
-            option routers $SUBNET.1;
-    }
+  subnet $SUBNET.0 netmask 255.255.255.0 {
+    range $SUBNET.100 $SUBNET.199;
+    option routers $SUBNET.1;
+  }
 EOF
   cp /dev/null /var/lib/dhcp/dhcpd.leases
 }
@@ -81,55 +71,29 @@ create_olsrd_config()
   wifidev="$1"
   SUBNET="$2"
   IPV6_PREFIX="$3"
-
   cat > /etc/olsrd/olsrd.conf <<- EOF
-  
   LinkQualityFishEye   0
 
   Interface "$wifidev"
-
   {
-
   }
 
   IpVersion               4
-
   LinkQualityFishEye      0
-
   LinkQualityAlgorithm "etx_ffeth_nl80211"
 
-  # This is only here to be able to generate a
-
-  # configuration file with the script
-
-  #LoadPlugin "/usr/lib/olsrd_jsoninfo.so.1.1"
-
-  #{
-
-    #PlParam "port"          "9090"
-
-    #PlParam "accept"        "0.0.0.0"
-
-  #}
-
-  # load arprefresh plugin
-
-  # - UDP packets on port 698
-
   LoadPlugin "/usr/lib/olsrd_arprefresh.so.0.1"  
-
   {
-
   }
 
   Hna4
   {
-          $SUBNET.0 255.255.255.0
+    $SUBNET.0 255.255.255.0
   }
 
   Hna6
   {
-          $IPV6_PREFIX:0 64
+    $IPV6_PREFIX:0 64
   }
 EOF
 }
@@ -137,14 +101,13 @@ EOF
 create_radvd_config()
 {
   IPV6_PREFIX="$1"
-
   cat > /etc/radvd.conf <<- EOF
-    interface br-lan
-    {
-            AdvSendAdvert on;
-            prefix $IPV6_PREFIX:0/64 {
-            };
+  interface br-lan
+  {
+    AdvSendAdvert on;
+    prefix $IPV6_PREFIX:0/64 {
     };
+  };
 EOF
 }
 

--- a/modules/utils/docker/mcc_settings.sh
+++ b/modules/utils/docker/mcc_settings.sh
@@ -26,7 +26,7 @@ configure
 ###Deciding IP address to be assigned to br-lan from WiFi MAC
 mesh_if_mac="$(ip -brief link | grep "$mesh_if" | awk '{print $3; exit}')"
 ip_random="$(echo "$mesh_if_mac" | cut -b 16-17)"
-br_lan_ip="192.168.3."$((16#$ip_random))
+br_lan_ip="192.168.$SUBNET."$((16#$ip_random))
 ifname_ap="$(ifconfig -a | grep "wlan*" | awk -F':' '{ print $1 }')"
 wlp1s0_ip="192.168.11."$((16#$ip_random))
 ifconfig wlp1s0 "$wlp1s0_ip" 


### PR DESCRIPTION
To summarize our changes : 
1- we assigned a static IP address on the wlp1s0 interface to 192.168.11.  for the QoS-OLSR 
2- we  assigned a SUB NET  for QoS-OLSR or the br-lan to allow routing with the AP
3- we allowed QoS-OLSR to route on IPV4 or IPV6
4- we allowed QoS_OLSR to run on the background and to write into the configuration file OLSRD.conf  
