### PR TITLE
Add comms.setting support for MPTCP enable/disable

### DIFF
--- a/common/scripts/mesh-11s_nats.sh
+++ b/common/scripts/mesh-11s_nats.sh
@@ -615,6 +615,9 @@ main () {
   _batman_iface="${INDEX}_BATMAN_IFACE"
   batman_iface="${!_batman_iface}"
 
+  _mptcp="${INDEX}_MPTCP"
+  mptcp="${!_mptcp}"        # enable disable
+
   # shellcheck disable=SC2153
   # shellcheck disable=SC2034
   # this is for the future use

--- a/modules/sc-mesh-secure-deployment/src/nats/scripts/cli_settings_request.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/scripts/cli_settings_request.py
@@ -3,6 +3,7 @@ import client
 import json
 import config
 
+
 async def main():
     # Connect to NATS!
     nc = await client.connect_nats()
@@ -19,6 +20,7 @@ async def main():
                 "frequency": "2412",
                 "frequency_mcc": "2412",  # multiradio not supporting
                 "routing": "batman-adv",
+                "mptcp": "disable",          # MPTCP support feature flag, enable/disable
                 "priority": "long_range",
                 "ip": "10.20.15.3",
                 "subnet": "255.255.255.0",
@@ -36,6 +38,7 @@ async def main():
                 "frequency": "5220",
                 "frequency_mcc": "2412",  # multiradio not supporting
                 "routing": "batman-adv",
+                "mptcp": "disable",          # MPTCP support feature flag, enable/disable
                 "priority": "long_range",
                 "ip": "10.20.15.3",
                 "subnet": "255.255.255.0",
@@ -53,6 +56,7 @@ async def main():
                 "frequency": "5190",
                 "frequency_mcc": "2412",  # multiradio not supporting
                 "routing": "batman-adv",
+                "mptcp": "disable",          # MPTCP support feature flag, enable/disable
                 "priority": "long_range",
                 "ip": "10.20.15.3",
                 "subnet": "255.255.255.0",
@@ -62,7 +66,7 @@ async def main():
                 "batman_iface": "bat0",
             },
         ],
-        "bridge": "br-lan bat0 eth1 lan1 eth0 usb0"
+        "bridge": "br-lan bat0 eth1 lan1 eth0 usb0",
     }
 
     cmd = json.dumps(cmd_dict)

--- a/modules/sc-mesh-secure-deployment/src/nats/src/comms_settings.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/comms_settings.py
@@ -25,23 +25,24 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
     def __init__(self, comms_status: [cs.CommsStatus, ...], logger):
         self.logger: logging = logger
         self.api_version: int = 1
-        self.radio_index = []
-        self.ssid = []
-        self.key = []
-        self.ap_mac = []
-        self.country = []
-        self.frequency = []
-        self.frequency_mcc = []
-        self.ip_address = []
-        self.subnet = []
-        self.tx_power = []
-        self.mode = []
-        self.routing = []
-        self.priority = []
+        self.radio_index: [int, ...] = []
+        self.ssid: [str, ...] = []
+        self.key: [str, ...] = []
+        self.ap_mac: [str, ...] = []
+        self.country: [str, ...] = []
+        self.frequency: [str, ...] = []
+        self.frequency_mcc: [str, ...] = []
+        self.ip_address: [str, ...] = []
+        self.subnet: [str, ...] = []
+        self.tx_power: [str, ...] = []
+        self.mode: [str, ...] = []
+        self.routing: [str, ...] = []
+        self.priority: [str, ...] = []
         self.role: str = ""
-        self.mesh_vif = []
+        self.mesh_vif: [str, ...] = []
+        self.mptcp: [str, ...] = []
         # self.phy = []
-        self.batman_iface = []
+        self.batman_iface: [str, ...] = []
         self.bridge: str = ""
         self.msversion: str = ""
         self.delay: str = ""  # delay for channel change
@@ -110,6 +111,10 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
             return "FAIL", "Invalid mesh vif"
         self.logger.debug("validate mesh settings mesh vif ok")
 
+        if validation.validate_mptcp(self.mptcp[index]) is False:
+            return "FAIL", "Invalid mptcp value"
+        self.logger.debug("validate mesh settings mptcp ok")
+
         # if validation.validate_phy(self.phy[index]) is False:
         #     return "FAIL", "Invalid phy"
         # self.logger.debug("validate mesh settings phy ok")
@@ -138,6 +143,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
         self.routing: [str, ...] = []
         self.priority: [str, ...] = []
         self.mesh_vif: [str, ...] = []
+        self.mptcp: [str, ...] = []
         # self.phy = []
         self.batman_iface: [str, ...] = []
 
@@ -235,6 +241,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
                 self.routing.append(quote(str(parameters["routing"])))
                 self.priority.append(quote(str(parameters["priority"])))
                 self.mesh_vif.append(quote(str(parameters["mesh_vif"])))
+                self.mptcp.append(quote(str(parameters["mptcp"])))
                 # self.phy.append(quote(str(parameters["phy"])))
                 self.batman_iface.append(quote(str(parameters["batman_iface"])))
 
@@ -329,6 +336,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
                 mesh_conf.write(
                     f"id{str(index)}_MESH_VIF={quote(self.mesh_vif[index])}\n"
                 )
+                mesh_conf.write(f"id{str(index)}_MPTCP={quote(self.mptcp[index])}\n")
                 # mesh_conf.write(f"id{str(index)}_PHY={quote(self.phy[index])}\n")
                 mesh_conf.write(
                     f"id{str(index)}_BATMAN_IFACE={quote(self.batman_iface[index])}\n"
@@ -379,6 +387,8 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
                     self.priority.append(match[1])
                 elif name == "MESH_VIF":
                     self.mesh_vif.append(match[1])
+                elif name == "MPTCP":
+                    self.mptcp.append(match[1])
                 # elif name == "PHY":
                 #     self.phy.append(match[1])
                 elif name == "BATMAN_IFACE":

--- a/modules/sc-mesh-secure-deployment/src/nats/src/validation.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/validation.py
@@ -286,3 +286,14 @@ def validate_batman_iface(batman_iface: str) -> bool:
         return False
     except (ValueError, TypeError, AttributeError):
         return False
+def validate_mptcp(mptcp: str) -> bool:
+    """
+    Validates a given mptcp.
+    Returns True if the mptcp is valid, False otherwise.
+    """
+    try:
+        if mptcp in ("enable", "disable"):
+            return True
+        return False
+    except (ValueError, TypeError, AttributeError):
+        return False


### PR DESCRIPTION
Adds configurability support to enable/disable a feature.  Currently creates a configuration item, but it is not yet used.

Jira-Id: WC-264