### PR TITLE
MDM SLAAC integration

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/scripts/cli_settings_request.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/scripts/cli_settings_request.py
@@ -29,6 +29,7 @@ async def main():
                 "mesh_vif": "wlp2s0",
                 "batman_iface": "bat0",
                 "bridge": "br-lan bat0 eth1 lan1 eth0 usb0",
+                "slaac": "usb0 wlp2s0", # SLAAC support for usb0 + mesh_vif
             },
             {
                 "radio_index": "1",
@@ -48,6 +49,7 @@ async def main():
                 "mesh_vif": "wlp3s0",  # this needs to be correct
                 "batman_iface": "bat0",
                 "bridge": "br-lan bat0 eth1 lan1 eth0 usb0",
+                "slaac": "usb0 wlp3s0", # SLAAC support for usb0 + mesh_vif
             },
             {
                 "radio_index": "2",
@@ -67,6 +69,7 @@ async def main():
                 "mesh_vif": "halow1",
                 "batman_iface": "bat0",
                 "bridge": "br-lan bat0 eth1 lan1 eth0 usb0",
+                "slaac": "usb0 halow1", # SLAAC support for usb0 + mesh_vif
             },
         ],
     }

--- a/modules/sc-mesh-secure-deployment/src/nats/src/comms_settings.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/comms_settings.py
@@ -44,6 +44,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
         # self.phy = []
         self.batman_iface = []
         self.bridge = []
+        self.slaac = []
         self.msversion: str = ""
         self.delay: str = ""  # delay for channel change
         self.comms_status = comms_status
@@ -123,6 +124,10 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
             return "FAIL", "Invalid batman iface"
         self.logger.debug("validate mesh settings batman iface ok")
 
+        if validation.validate_slaac(self.slaac[index]) is False:
+            return "FAIL", "Invalid slaac ifaces"
+        self.logger.debug("validate mesh settings slaac ifaces ok")
+
         return "OK", "Mesh settings OK"
 
     def __clean_all_settings(self) -> None:
@@ -147,6 +152,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
         # self.phy = []
         self.batman_iface: [str, ...] = []
         self.bridge: [str, ...] = []
+        self.slaac: [str, ...] = []
 
     def handle_mesh_settings_channel_change(
         self, msg: str, path="/opt", file="mesh_stored.conf"
@@ -246,6 +252,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
                 # self.phy.append(quote(str(parameters["phy"])))
                 self.batman_iface.append(quote(str(parameters["batman_iface"])))
                 self.bridge.append(str(parameters["bridge"]))
+                self.slaac.append(str(parameters["slaac"]))
 
             for index in self.radio_index:
                 self.logger.debug("Mesh settings validation index: %s", str(index))
@@ -295,7 +302,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
                 index = 0
             self.comms_status[index].mesh_cfg_status = comms.STATUS.mesh_cfg_not_stored
             ret, _ = "FAIL", self.comms_status[index].mesh_cfg_status
-            info = "JSON format not correct" + str(error)
+            info = "JSON format not correct " + str(error)
             self.logger.error("Mesh settings validation: %s, %s", ret, info)
 
         return ret, info
@@ -342,6 +349,7 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
                     f"id{str(index)}_BATMAN_IFACE={quote(self.batman_iface[index])}\n"
                 )
                 mesh_conf.write(f"id{str(index)}_BRIDGE={quote(self.bridge[index])}\n")
+                mesh_conf.write(f"id{str(index)}_SLAAC={quote(self.slaac[index])}\n")
 
         except:
             self.comms_status[index].mesh_cfg_status = comms.STATUS.mesh_cfg_not_stored
@@ -395,6 +403,8 @@ class CommsSettings:  # pylint: disable=too-few-public-methods, too-many-instanc
                     self.batman_iface.append(match[1])
                 elif name == "BRIDGE":
                     self.bridge.append(match[1])
+                elif name == "SLAAC":
+                    self.slaac.append(match[1])
                 else:
                     self.logger.error("unknown config parameter: %s", name)
             else:  # global config without index

--- a/modules/sc-mesh-secure-deployment/src/nats/src/validation.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/validation.py
@@ -286,6 +286,7 @@ def validate_batman_iface(batman_iface: str) -> bool:
         return False
     except (ValueError, TypeError, AttributeError):
         return False
+
 def validate_mptcp(mptcp: str) -> bool:
     """
     Validates a given mptcp.
@@ -295,5 +296,20 @@ def validate_mptcp(mptcp: str) -> bool:
         if mptcp in ("enable", "disable"):
             return True
         return False
+    except (ValueError, TypeError, AttributeError):
+        return False
+
+def validate_slaac(slaac: str) -> bool:
+    """
+    Validates a given slaac ifaces.
+    Returns True if the slaac ifaces are valid, False otherwise.
+    """
+    try:
+        for slaac_if in slaac.split():
+            if (not slaac_if.startswith("wl") and
+                    not slaac_if.startswith("halow") and
+                    not slaac_if.startswith("usb")):
+                return False
+        return True
     except (ValueError, TypeError, AttributeError):
         return False


### PR DESCRIPTION
I have tested this changes as follow:
```
root@br_hardened:~# /opt/S90mdm_agent start
-k /etc/ssl/private/csl1.local.key -c /etc/ssl/certs/csl1.local.crt -r /etc/ssl/certs/ca.crt --agent mdm
Starting comms_nats_controller.py: OK
root@br_hardened:~# cat /opt/mdm_agent.log
2023-11-16 09:16:24,574 :: comms.status 0     :: DEBUG    :: mesh_cfg_status=MESH_CONFIGURATION_NOT_STORED, is_mission_cfg=False,
2023-11-16 09:16:24,603 :: comms.status 0     :: DEBUG    :: wpa_supplicant PID: 1616
2023-11-16 09:16:24,622 :: comms.status 0     :: DEBUG    :: interface=wlp1s0
2023-11-16 09:16:24,623 :: comms.status 0     :: DEBUG    :: bssid=00:00:00:00:00:00
2023-11-16 09:16:24,623 :: comms.status 0     :: DEBUG    :: freq=5805
2023-11-16 09:16:24,623 :: comms.status 0     :: DEBUG    :: ssid=gold
2023-11-16 09:16:24,623 :: comms.status 0     :: DEBUG    :: id=0
2023-11-16 09:16:24,623 :: comms.status 0     :: DEBUG    :: mode=mesh
2023-11-16 09:16:24,624 :: comms.status 0     :: DEBUG    :: pairwise_cipher=UNKNOWN
2023-11-16 09:16:24,624 :: comms.status 0     :: DEBUG    :: group_cipher=UNKNOWN
2023-11-16 09:16:24,624 :: comms.status 0     :: DEBUG    :: key_mgmt=UNKNOWN
2023-11-16 09:16:24,624 :: comms.status 0     :: DEBUG    :: wpa_state=COMPLETED
2023-11-16 09:16:24,624 :: comms.status 0     :: DEBUG    :: address=00:30:1a:4f:c8:49
2023-11-16 09:16:24,624 :: comms.status 0     :: DEBUG    :: uuid=a27a10da-e296-54fd-b424-7160e0cb089a
2023-11-16 09:16:24,651 :: comms.status 1     :: DEBUG    :: mesh_cfg_status=MESH_CONFIGURATION_NOT_STORED, is_mission_cfg=False,
2023-11-16 09:16:24,677 :: comms.status 1     :: DEBUG    :: wpa_supplicant PID:
2023-11-16 09:16:24,705 :: comms.status 2     :: DEBUG    :: mesh_cfg_status=MESH_CONFIGURATION_NOT_STORED, is_mission_cfg=False,
2023-11-16 09:16:24,731 :: comms.status 2     :: DEBUG    :: wpa_supplicant PID:
2023-11-16 09:16:24,758 :: comms.settings     :: DEBUG    :: mesh config file /opt/0_mesh.conf not found, loading default
2023-11-16 09:16:24,760 :: comms.settings     :: DEBUG    :: index not supported for default: 1
2023-11-16 09:16:24,761 :: comms.settings     :: DEBUG    :: index not supported for default: 2
2023-11-16 09:16:24,761 :: comms.settings     :: DEBUG    :: load settings: OK, Mesh configuration loaded
2023-11-16 09:16:24,764 :: comms.controller   :: DEBUG    :: MDM: comms_nats_controller Listening for requests
2023-11-16 09:16:25,820 :: comms.controller   :: DEBUG    :: HTTP Request status: 200
2023-11-16 09:16:25,821 :: comms.controller   :: DEBUG    :: HTTP Request Response: {"version":0,"payload":{"api_version":1,"radios":[{"radio_index":"0","ssid":"test_mesh","key":"1234567890","ap_mac":"00:11:22:33:44:55","country":"FI","frequency":"5220","frequency_mcc":"2412","routing":"batman-adv","mptcp":"disable","ip":"192.168.1.2","subnet":"255.255.255.0","tx_power":"5","mode":"ap+mesh_scc","priority":"long_range","mesh_vif":"halow1","batman_iface":"bat0","bridge":"br-lan bat0 eth1 lan1 eth0 usb0","slaac":"usb0 halow1"}],"role":"sleeve"}} 200
2023-11-16 09:16:25,822 :: comms.settings     :: DEBUG    :: Mesh settings validation index: 0
2023-11-16 09:16:25,823 :: comms.settings     :: DEBUG    :: validate mesh settings
2023-11-16 09:16:25,824 :: comms.settings     :: DEBUG    :: validate mesh settings ssid ok
2023-11-16 09:16:25,825 :: comms.settings     :: DEBUG    :: validate mesh settings wpa3 ok
2023-11-16 09:16:25,825 :: comms.settings     :: DEBUG    :: validate mesh settings ip ok
2023-11-16 09:16:25,825 :: comms.settings     :: DEBUG    :: validate mesh settings mode ok
2023-11-16 09:16:25,826 :: comms.settings     :: DEBUG    :: validate mesh settings freq ok
2023-11-16 09:16:25,826 :: comms.settings     :: DEBUG    :: validate mesh settings mcc freq ok
2023-11-16 09:16:25,826 :: comms.settings     :: DEBUG    :: validate mesh settings country ok
2023-11-16 09:16:25,827 :: comms.settings     :: DEBUG    :: validate mesh settings subnet ok
2023-11-16 09:16:25,827 :: comms.settings     :: DEBUG    :: validate mesh settings tx power ok
2023-11-16 09:16:25,827 :: comms.settings     :: DEBUG    :: validate mesh settings routing ok
2023-11-16 09:16:25,827 :: comms.settings     :: DEBUG    :: validate mesh settings priority ok
2023-11-16 09:16:25,828 :: comms.settings     :: DEBUG    :: validate mesh settings role ok
2023-11-16 09:16:25,828 :: comms.settings     :: DEBUG    :: validate mesh settings mesh vif ok
2023-11-16 09:16:25,828 :: comms.settings     :: DEBUG    :: validate mesh settings mptcp ok
2023-11-16 09:16:25,828 :: comms.settings     :: DEBUG    :: validate mesh settings batman iface ok
2023-11-16 09:16:25,829 :: comms.settings     :: DEBUG    :: validate mesh settings slaac ifaces ok
2023-11-16 09:16:25,829 :: comms.settings     :: DEBUG    :: Mesh settings validation id 0: OK, Mesh settings OK
2023-11-16 09:16:25,830 :: comms.settings     :: DEBUG    :: 0_mesh_stored.conf written
2023-11-16 09:16:25,830 :: comms.settings     :: DEBUG    :: save settings index 0: OK, Mesh configuration stored
2023-11-16 09:16:25,831 :: comms.controller   :: DEBUG    :: ret: OK info: Mesh configuration stored
2023-11-16 09:16:25,831 :: comms.command      :: DEBUG    :: Command: APPLY
2023-11-16 09:16:29,159 :: comms.command      :: DEBUG    :: Mission configurations applied
2023-11-16 09:16:29,159 :: comms.controller   :: DEBUG    :: ret: OK info: Mission configurations applied
2023-11-16 09:16:29,160 :: comms.controller   :: ERROR    :: KeyError features field in config
root@br_hardened:~#
```

I only have doubt related to this last `2023-11-16 09:16:29,160 :: comms.controller   :: ERROR    :: KeyError features field in config`. I will check soon if it is because of my fixes, and if does, how can I fix it. So I will do some more test but now I am creating this PR because it is basically what Mika asked and maybe there will be some more notes and ideas. Also, Mika, if you have any ideas on this `ERROR    :: KeyError features field in config` please share.

On server side I just used this patch for testing:
```
(venv) daniil@daniil-ThinkPad-T14-Gen-3:~/workspace/TC_DISTRO/BUILD/MDM/mdm-server$ git diff
diff --git a/configuration/MeshConf.py b/configuration/MeshConf.py
index 19b5e3d..5ef29a4 100644
--- a/configuration/MeshConf.py
+++ b/configuration/MeshConf.py
@@ -39,6 +39,7 @@ class MeshConf(Dict):
         self['mesh_vif'] = self.mesh_vif if self.mesh_vif else 'halow1'
         self['batman_iface'] = self.batman_iface if self.batman_iface else 'bat0'
         self['bridge'] = 'br-lan bat0 eth1 lan1 eth0 usb0'
+        self['slaac'] = 'usb0 ' + self['mesh_vif']
 
     @staticmethod
     def from_json(json_str: str) -> MeshConf:
(venv) daniil@daniil-ThinkPad-T14-Gen-3:~/workspace/TC_DISTRO/BUILD/MDM/mdm-server$ 
```
I will create PR accordingly as soon as I get credentials from Seb. 