### PR TITLE
debug command and SLAAC test

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/comms_nats_controller.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/comms_nats_controller.py
@@ -568,15 +568,14 @@ class MdmAgent:
             ):
                 self.__debug_config_interval = self.OK_POLLING_TIME_SECONDS
                 self.__mesh_conf_request_processed = False
-            elif (
-                response.status_code == 405
-            ):
-                self.__comms_controller.logger.debug(
-                    "MDM Server has no support for debug mode"
-                )
-                self.__debug_config_interval = self.OK_POLLING_TIME_SECONDS
             elif response.text.strip() == "" or response.status_code != 200:
                 self.__debug_config_interval = self.FAIL_POLLING_TIME_SECONDS
+                if response.status_code == 405:
+                    self.__comms_controller.logger.debug(
+                        "MDM Server has no support for debug mode"
+                    )
+                    self.__debug_config_interval = self.OK_POLLING_TIME_SECONDS
+                    self.__mesh_conf_request_processed = False
         else:
             if (
                 response.status_code == 200

--- a/modules/sc-mesh-secure-deployment/src/nats/comms_nats_controller.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/comms_nats_controller.py
@@ -568,6 +568,13 @@ class MdmAgent:
             ):
                 self.__debug_config_interval = self.OK_POLLING_TIME_SECONDS
                 self.__mesh_conf_request_processed = False
+            elif (
+                response.status_code == 405
+            ):
+                self.__comms_controller.logger.debug(
+                    "MDM Server has no support for debug mode"
+                )
+                self.__debug_config_interval = self.OK_POLLING_TIME_SECONDS
             elif response.text.strip() == "" or response.status_code != 200:
                 self.__debug_config_interval = self.FAIL_POLLING_TIME_SECONDS
         else:

--- a/modules/sc-mesh-secure-deployment/src/nats/debug_tests/README.md
+++ b/modules/sc-mesh-secure-deployment/src/nats/debug_tests/README.md
@@ -1,0 +1,27 @@
+# For a Debug testing
+
+## Overview
+
+This folder includes initial debug tests.
+By default it is not allowed to run DEBUG COMMAND but you can get permissions (`debug_conf`) from MDM server.
+Test is utilizing NATS.io interface to send messages to Comms Controller.
+
+## Debug Tests
+
+### To execute
+
+- Please set correct device lan1/eth0 IP address to config.py
+- then execute
+```
+python3 -m unittest discover --verbose
+```
+
+## Coverage
+
+    async def test_identity(self):
+    async def test_status(self):
+    async def test_debug(self): (cat build.info command)
+    async def test_slaac(self): (apply slaac command + ifconfig to check results)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/sc-mesh-secure-deployment/src/nats/debug_tests/client.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/debug_tests/client.py
@@ -1,0 +1,51 @@
+import ssl
+import os
+import nats
+from nats.aio.client import Client
+import config
+
+client_cert = "/etc/ssl/certs/comms_auth_cert.pem"
+key = "/etc/ssl/private/comms_auth_private_key.pem"
+ca_cert = "/etc/ssl/certs/root-ca.cert.pem"
+
+
+async def connect_nats():
+    if os.path.exists(client_cert) and \
+       os.path.exists(key) and \
+       os.path.exists(ca_cert):
+
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_cert_chain(certfile=client_cert, keyfile=key)
+        ssl_context.load_verify_locations(cafile=ca_cert)
+
+        nats_client = await nats.connect(f"{config.MODULE_IP}:{config.MODULE_PORT}",
+                                         tls=ssl_context)
+
+    else:
+        nats_client = await nats.connect(f"{config.MODULE_IP}:{config.MODULE_PORT}")
+
+    return nats_client
+
+
+async def connect(nats_client: Client, recon_cb=None, closed_cb=None, max_reconnection_attempts=None):
+    if os.path.exists(client_cert) and \
+       os.path.exists(key) and \
+       os.path.exists(ca_cert):
+
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_cert_chain(certfile=client_cert, keyfile=key)
+        ssl_context.load_verify_locations(cafile=ca_cert)
+
+        await nats_client.connect(f"{config.MODULE_IP}:{config.MODULE_PORT}",
+                                  tls=ssl_context,
+                                  reconnected_cb=recon_cb,
+                                  closed_cb=closed_cb,
+                                  max_reconnect_attempts=max_reconnection_attempts)
+
+    else:
+        await nats_client.connect(f"{config.MODULE_IP}:{config.MODULE_PORT}",
+                                  reconnected_cb=recon_cb,
+                                  closed_cb=closed_cb,
+                                  max_reconnect_attempts=max_reconnection_attempts)
+
+    return None

--- a/modules/sc-mesh-secure-deployment/src/nats/debug_tests/config.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/debug_tests/config.py
@@ -1,0 +1,19 @@
+"""
+This file contains the configuration for the NATS client.
+"""
+try:
+    from identity import MODULE_IDENTITY as IDENTITY
+except ImportError:
+    IDENTITY = "no_identity"
+    print("No identity found!!!!!!!!!!!!!!!!!!!!!!!!")
+    print("Please run _cli_command_get_identity.py to get the identity (creates identity.py)")
+
+MODULE_IP = "192.168.1.124"   # - brlan ip address
+MODULE_PORT = "4222"
+
+# IPv6 connection example
+# MODULE_IP = "[2001:db8:1234:5678:2e0:4cff:fe68:7a73]"
+# MODULE_PORT = "6222"
+
+MODULE_ROLE = "drone"  # drone, sleeve or gcs
+MODULE_IDENTITY = IDENTITY  # messages are sent to this device

--- a/modules/sc-mesh-secure-deployment/src/nats/debug_tests/test_debug.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/debug_tests/test_debug.py
@@ -1,0 +1,129 @@
+"""
+Debug test to test the DEBUG COMMAND
+"""
+import unittest
+import json
+import base64
+import asyncio
+from nats.aio.client import Client as NATS
+
+try:
+    import config
+    import client
+
+    SKIP_TEST = False
+except ModuleNotFoundError:
+    SKIP_TEST = True
+
+
+@unittest.skipIf(
+    SKIP_TEST, "Debug tests need to be executed from the script directory"
+)
+class TestDebug(unittest.IsolatedAsyncioTestCase):
+    """
+    Debug test to test the DEBUG COMMAND
+    """
+
+    async def test_identity(self):
+        """
+        Test cases for comms_settings.py
+        """
+        received = False
+        # settings json is valid
+        nc = await client.connect_nats()
+        cmd_dict = {"api_version": 1, "cmd": "GET_IDENTITY"}
+        cmd = json.dumps(cmd_dict)
+        rep = await nc.request("comms.identity", cmd.encode(), timeout=2)
+
+        parameters = json.loads(rep.data.decode())
+
+        if "identity" in parameters["data"]:
+            with open("identity.py", "w", encoding="utf-8") as f:
+                f.write(f"MODULE_IDENTITY=\"{parameters['data']['identity']}\"\n")
+            received = True
+        else:
+            print("No identity received!!!!!!!!!!!")
+        await nc.close()
+
+        self.assertTrue(received)
+
+    async def test_status(self):
+        """
+        Test cases for comms
+        """
+        received = False
+        nc = await client.connect_nats()
+        cmd_dict = {"api_version": 1}
+        cmd = json.dumps(cmd_dict)
+        rep = await nc.request(
+            f"comms.status.{config.MODULE_IDENTITY}", cmd.encode(), timeout=1
+        )
+        parameters = json.loads(rep.data)
+        if parameters["status"] == "OK":
+            received = True
+        await nc.close()
+        self.assertTrue(received)
+
+    async def test_debug(self):
+        """
+        Test cases for comms
+        """
+        received = False
+
+        nc = await client.connect_nats()
+
+        cmd_dict = {"api_version": 1, "cmd": "DEBUG", "param": "cat /root/build.info"}
+        cmd = json.dumps(cmd_dict)
+        rep = await nc.request(
+            f"comms.command.{config.MODULE_IDENTITY}", cmd.encode(), timeout=5
+        )
+        parameters = json.loads(rep.data.decode())
+        if parameters["status"] == "OK":
+            received = True
+        print(parameters["info"])
+
+        self.assertTrue(received)
+        b64_data = base64.b64decode(parameters["data"].encode())
+        print(b64_data.decode())
+
+    async def test_slaac(self):
+        """
+        Test cases for comms
+        """
+        received = False
+
+        nc = await client.connect_nats()
+
+        cmd_dict = {"api_version": 1, "cmd": "DEBUG", "param": "/opt/slaac.sh wlp1s0"}
+        cmd = json.dumps(cmd_dict)
+        rep = await nc.request(
+            f"comms.command.{config.MODULE_IDENTITY}", cmd.encode(), timeout=5
+        )
+        parameters = json.loads(rep.data.decode())
+        if parameters["status"] == "OK":
+            received = True
+        print(parameters["info"])
+
+        self.assertTrue(received)
+        b64_data = base64.b64decode(parameters["data"].encode())
+        print(b64_data.decode())
+
+        await asyncio.sleep(float(40))
+
+        cmd_dict = {"api_version": 1, "cmd": "DEBUG", "param": "ifconfig wlp1s0"}
+        cmd = json.dumps(cmd_dict)
+        rep = await nc.request(
+            f"comms.command.{config.MODULE_IDENTITY}", cmd.encode(), timeout=5
+        )
+        parameters = json.loads(rep.data.decode())
+        if parameters["status"] == "OK":
+            received = True
+        print(parameters["info"])
+
+        self.assertTrue(received)
+        b64_data = base64.b64decode(parameters["data"].encode())
+        print(b64_data.decode())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/sc-mesh-secure-deployment/src/nats/examples/cli_command_debug.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/examples/cli_command_debug.py
@@ -1,0 +1,28 @@
+import asyncio
+import client
+import json
+import base64
+import config
+
+
+async def main():
+    # Connect to NATS!
+    nc = await client.connect_nats()
+
+    cmd_dict = {"api_version": 1, "cmd": "DEBUG", "param": "cat /root/build.info"}
+    cmd = json.dumps(cmd_dict)
+    rep = await nc.request(f"comms.command.{config.MODULE_IDENTITY}",
+                           cmd.encode(),
+                           timeout=2)
+    print(rep.data)
+    parameters = json.loads(rep.data.decode())
+    b64_data = base64.b64decode(parameters["data"].encode())
+    print(b64_data.decode())
+
+    await nc.close()
+    exit(0)
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
+    loop.close()

--- a/modules/sc-mesh-secure-deployment/src/nats/src/comms_common.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/comms_common.py
@@ -38,3 +38,4 @@ class COMMAND:  # pylint: disable=too-few-public-methods
     disable_visualisation: str = "DISABLE_VISUALISATION"
     get_config: str = "GET_CONFIG"
     get_identity: str = "GET_IDENTITY"
+    debug: str = "DEBUG"     # DEBUG command allows to run any subprocess, it is disabled by default


### PR DESCRIPTION
Hi!
In this PR I introduce DEBUG COMMAND which can run any subprocess via comms_controller requests.
It is disabled by default.
MDM agent requests MDM server for `debug_conf` and store it to `/opt/debug_config.json`
I will create PR for server side soon.
This config looks like:
```
{"version":0,"payload":{"api_version":1,"role":"sleeve","debug_conf":[{"debug_mode":"disabled","rsyslog_addr":"172.25.26.140"}]}}
```
or
```
{"version":0,"payload":{"api_version":1,"role":"sleeve","debug_conf":[{"debug_mode":"enabled","rsyslog_addr":"172.25.26.140"}]}}
```
If `debug_mode` is `enabled` it is possible to use DEBUG COMMAND.
I have added `cli example` accordingly.
I also use this DEBUG COMMAND to test SLAAC in `debug_tests` folder.