### PR TITLE
SECO-3123: nrc1.5.0 update - setting long guard interval and support_ch_width

### DIFF
--- a/common/scripts/mesh-11s_nats.sh
+++ b/common/scripts/mesh-11s_nats.sh
@@ -314,6 +314,8 @@ EOF
       # Radio parameters
       echo "set radio parameters"
       # /usr/local/bin/cli_app set txpwr fixed 23
+      /usr/local/bin/cli_app set gi long
+      /usr/local/bin/cli_app set support_ch_width 1
 
       # Batman parameters
       batctl "$wifidev" hop_penalty 30


### PR DESCRIPTION
Due to latest halow nrc driver update, some of the default values are changed. To make it same as previous version, we need to apply these settings.