### PR TITLE
CBMA High CPU Usage Fix

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/2_0/features/cbma/tools/monitoring_wpa.py
+++ b/modules/sc-mesh-secure-deployment/src/2_0/features/cbma/tools/monitoring_wpa.py
@@ -34,6 +34,7 @@ class WPAMonitor:
                     response = ctrl.recv()
                     decoded_response = response.decode().strip()
                     self._handle_event(decoded_response, queue)
+                time.sleep(1)
 
     def _handle_event(self, decoded_response, queue):
         # Check for the MESH-PEER-CONNECTED event


### PR DESCRIPTION
This PR adds a 1 second delay to prevent high CPU usage due to polling a non-blocking socket :building_construction: 

Jira-Id: SECO-3343