### PR TITLE
Add Basic Acceptance tests for CBMA

### DIFF
--- a/common/tests/functional/test_cbma/cbma_check_enabled.sh
+++ b/common/tests/functional/test_cbma/cbma_check_enabled.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+features_yaml="/opt/mesh_com/modules/sc-mesh-secure-deployment/src/2_0/features.yaml"
+state="$(awk '/CBMA/{print $2}' $features_yaml)"
+
+if [ "$state" != "true" ]; then
+    echo "Fail"
+    exit 1
+fi
+echo "Pass"

--- a/common/tests/functional/test_cbma/cbma_check_lower_running.sh
+++ b/common/tests/functional/test_cbma/cbma_check_lower_running.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+(
+    cd "$(dirname "$0")"
+
+    sh ./cbma_check_running.sh lower
+)

--- a/common/tests/functional/test_cbma/cbma_check_running.sh
+++ b/common/tests/functional/test_cbma/cbma_check_running.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+mdm_constants='/opt/mesh_com/modules/sc-mesh-secure-deployment/src/nats/src/constants.py'
+lower_or_upper="$(awk "BEGIN{print toupper(\"$1\")}")"
+
+if [ $# -ne 1 ] || case "$lower_or_upper" in LOWER|UPPER) false;; esac; then
+    echo "Usage: $0 <lower|upper>"
+    exit 1
+fi
+
+port="$(awk "/^[[:space:]]*CBMA_PORT_${lower_or_upper}/{print \$NF}" $mdm_constants)"
+
+if ! ss -lp | grep -q "\\b$port\\b.*python"; then
+    echo "Fail"
+    exit 1
+fi
+echo "Pass"

--- a/common/tests/functional/test_cbma/cbma_check_upper_running.sh
+++ b/common/tests/functional/test_cbma/cbma_check_upper_running.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+(
+    cd "$(dirname "$0")"
+
+    sh ./cbma_check_running.sh upper
+)


### PR DESCRIPTION
The title :arrow_up_small: 

The tests check that:
- CBMA is enabled by checking `features.yaml` (temporarily until it's part of the core)
- CBMA is running by checking that its server is listening on the specified ports

The tests assume that CBMA is launched by the `comms_nat_controller.py` script :t-rex: 

Jira-ID: SECO-2687