### PR TITLE
Update LDPI test files

### DIFF
--- a/common/tests/functional/test_ldpi/sniffer_test.py
+++ b/common/tests/functional/test_ldpi/sniffer_test.py
@@ -1,0 +1,75 @@
+from unittest.mock import Mock, patch
+import sys
+import dpkt
+import pytest
+
+sys.path.insert(0, '/opt/mesh_com/modules/sc-mesh-secure-deployment/src/2_0/features/ldpi')
+from options import SnifferOptions
+from sniffer.sniffer import Sniffer
+
+
+class TestSniffer:
+    @pytest.fixture
+    def mock_options(self):
+        return SnifferOptions()
+
+    @pytest.fixture
+    def sniffer(self, mock_options):
+        return Sniffer(mock_options)
+
+    def test_initialization(self, sniffer, mock_options):
+        assert sniffer.args == mock_options
+        assert sniffer.timeout_ns == int(mock_options.timeout * 1e+9)
+        assert isinstance(sniffer.flows_tcp, dict)
+        assert isinstance(sniffer.flows_udp, dict)
+
+    @pytest.mark.parametrize("eth_type, is_batman, is_broadcast, nested_eth_type, should_unpack", [
+        (dpkt.ethernet.ETH_TYPE_IP, False, False, None, True),
+        (dpkt.ethernet.ETH_TYPE_IP6, False, False, None, True),
+        (17157, True, True, None, False),  # batman type, broadcast (should return early)
+    ])
+    def test_process_packet(self, eth_type, is_batman, is_broadcast, nested_eth_type, should_unpack, sniffer):
+        len_eth = 14  # length of Ethernet header
+        len_bat = 10  # length of Batman header
+        mock_eth_data = b'\x00' * 60
+
+        # Creating separate mock buffers for batman and normal scenarios
+        batman_mock_buf = b'\x00' * len_eth + b'\x00' * len_bat + mock_eth_data
+        normal_mock_buf = b'\x00' * 60
+
+        mock_buf = batman_mock_buf if is_batman else normal_mock_buf
+
+        # Create a real Ethernet frame instance
+        mock_eth = dpkt.ethernet.Ethernet()
+        mock_eth.type = eth_type
+
+        # Set source and destination MAC addresses
+        mock_eth.src = b'\x00\x11\x22\x33\x44\x55'
+        mock_eth.dst = b'\x66\x77\x88\x99\xaa\xbb'
+
+        if is_batman:
+            mock_eth.dst = b'\xff\xff\xff\xff\xff\xff' if is_broadcast else b'\x00' * 6
+            if not is_broadcast and nested_eth_type is not None:
+                # Create a nested Ethernet frame
+                mock_nested_eth = Mock()
+                mock_nested_eth.type = nested_eth_type
+                mock_eth.data = mock_nested_eth
+
+        with patch('dpkt.ethernet.Ethernet', return_value=mock_eth):
+            if should_unpack:
+                with patch.object(sniffer, 'unpack_ip') as mock_unpack_ip:
+                    sniffer.process_packet(123456789, mock_buf)
+                    if nested_eth_type is not None and not is_broadcast:
+                        mock_unpack_ip.assert_called_with(mock_eth.data, 123456789, '00:11:22:33:44:55', '66:77:88:99:aa:bb')
+                    else:
+                        mock_unpack_ip.assert_called_with(mock_eth, 123456789, '00:11:22:33:44:55', '66:77:88:99:aa:bb')
+            else:
+                sniffer.process_packet(123456789, mock_buf)
+
+    @patch('dpkt.ethernet.Ethernet')
+    @patch('logging.warning')
+    def test_process_packet_exception(self, mock_logging, mock_ethernet, sniffer):
+        # Simulate a dpkt.dpkt.NeedData exception
+        mock_ethernet.side_effect = dpkt.dpkt.NeedData
+        sniffer.process_packet(123456789, b'')
+        mock_logging.assert_called_once_with('Packet -1 in PCAP file is truncated')

--- a/common/tests/functional/test_ldpi/trained_model_test.py
+++ b/common/tests/functional/test_ldpi/trained_model_test.py
@@ -1,0 +1,146 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, '/opt/mesh_com/modules/sc-mesh-secure-deployment/src/2_0/features/ldpi')
+from options import SnifferOptions
+from options import LDPIOptions
+from ldpi.inference import TrainedModel
+
+
+class TestTrainedModel:
+    @pytest.fixture
+    def mock_options(self):
+        options = LDPIOptions()
+        options.store_models_path = '/opt/mesh_com/modules/sc-mesh-secure-deployment/src/2_0/features/ldpi/ldpi/training/output/ResCNN/'
+        options.threshold_type = 'max'
+        options.n = 4
+        options.l = 60
+        options.model_name = 'ResCNN'
+        return options
+
+    class TestTrainedModelFileExistence:
+        def test_model_files_existence(self, mock_options):
+            model = TrainedModel(mock_options)
+            model_path = mock_options.store_models_path
+
+            # Define the expected file paths
+            expected_files = [
+                os.path.join(model_path, 'best_model_with_center.pth'),
+                os.path.join(model_path, 'scripted_quantized_model.pth'),
+                os.path.join(model_path, 'traced_model.pth')
+            ]
+
+            # Check if each file exists and can be loaded with PyTorch
+            for file_path in expected_files:
+                full_path = os.path.abspath(file_path)
+                print(f"Checking file: {full_path}")
+                assert os.path.exists(full_path), f"File not found: {file_path}"
+
+                # Attempt to load the model file with PyTorch
+                try:
+                    if 'scripted_quantized_model.pth' in full_path or 'traced_model.pth' in full_path:
+                        torch.backends.quantized.engine = 'qnnpack'
+                        # For model files, use torch.jit.load
+                        torch.jit.load(full_path, map_location=torch.device('cpu'))
+                    else:
+                        # For other .pth files, use torch.load
+                        torch.load(full_path, map_location=torch.device('cpu'))
+                except Exception as e:
+                    assert False, f"Failed to load file {file_path} with PyTorch: {e}"
+
+    @pytest.mark.parametrize("threshold_type, expected_threshold", [
+        ('ninety_nine', 0.99),
+        ('near_max', 0.9999),
+        ('max', 1.0),
+        ('hundred_one', 1.01),
+    ])
+    def test_initialize_threshold(self, mock_options, threshold_type, expected_threshold):
+        mock_options.threshold_type = threshold_type
+        model = TrainedModel(mock_options)
+        model_path = mock_options.store_models_path
+
+        # Mocking the thresholds as they are not set in the __init__ method
+        model.ninety_nine_threshold = 0.99
+        model.near_max_threshold = 0.9999
+        model.max_threshold = 1.0
+        model.hundred_one_threshold = 1.01
+
+        assert model._initialize_threshold() == expected_threshold, (f"Threshold initialization failed for threshold_type: {threshold_type}")
+
+    @pytest.fixture(scope="function")
+    def flow_data(self, mock_options):
+        num_packets = mock_options.n
+        len_packets = mock_options.l
+
+        # Create mock flow data
+        flow_key_1 = (b'\xC0\xA8\x00\x01', 12345, b'\xC0\xA8\x00\x02', 80, 6, '00:11:22:33:44:55', '00:11:22:33:44:66')
+        flow_key_2 = (b'\xC0\xA8\x00\x03', 12345, b'\xC0\xA8\x00\x04', 80, 17, '00:11:22:33:44:66', '00:11:22:33:44:55')
+
+        # Example numpy arrays representing packet data
+        flow_data_1 = [np.random.rand(len_packets).astype(np.float32) for _ in range(num_packets)]
+        flow_data_2 = [np.random.rand(len_packets).astype(np.float32) for _ in range(num_packets)]
+
+        return [(flow_key_1, flow_data_1), (flow_key_2, flow_data_2)]
+
+    @pytest.fixture
+    def black_list(self):
+        # Define a set of blacklisted IPs
+        return {b'\xC0\xA8\x00\x01', b'\xC0\xA8\x00\x05'}
+
+    def test_prepare_tensors(self, mock_options, flow_data, black_list):
+        mock_model = TrainedModel(mock_options)
+        mock_model.store_models_path = 'ldpi/training/output/traced_model.pth/'
+        flow_data_copy = flow_data.copy()
+        keys, tensor = mock_model.prepare_tensors(flow_data, black_list)
+
+        # Diagnostic print statements (optional, for debugging purposes)
+        print("Processed Keys:", keys)
+        print("Blacklist:", black_list)
+        print("Tensor Shape:", tensor.shape if tensor.numel() > 0 else "Empty Tensor")
+
+        # Check if blacklisted flows are excluded
+        for key in keys:
+            assert key[0] not in black_list, "Blacklisted flow key found in the processed keys"
+
+        # Check if the output tensor has the correct shape and type
+        assert isinstance(tensor, torch.Tensor), "Output is not a torch.Tensor"
+        assert tensor.dim() == 2, "Output tensor does not have the correct number of dimensions"
+
+        expected_non_blacklisted_flows = len([f for f, _ in flow_data_copy if f[0] not in black_list])
+
+        # Check if the number of non-blacklisted flows matches the tensor's first dimension
+        assert tensor.shape[0] == expected_non_blacklisted_flows, f"Output tensor does not match the number of non-blacklisted flows {tensor.shape}"
+
+        # Check if the second dimension of the tensor matches the expected shape per flow
+        assert tensor.shape[1] == mock_model.args.l * mock_model.args.n, "Output tensor does not have the correct shape per flow"
+
+    def test_infer_anomalies(self, mock_options):
+        # Create a mock TrainedModel instance
+        model = TrainedModel(mock_options)
+        model_path = mock_options.store_models_path
+
+        # Mock the model's encode method
+        model.model = MagicMock()
+        mock_encoded_output = torch.tensor([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
+        model.model.encode.return_value = mock_encoded_output
+
+        # Define the center and threshold for testing
+        model.center = torch.tensor([0.2, 0.3])
+        model.chosen_threshold = 0.05
+
+        # Prepare mock network flows tensor
+        mock_network_flows = torch.rand((3, model.args.n * model.args.l))
+
+        # Invoke the infer method
+        anomalies = model.infer(mock_network_flows)
+
+        # Calculate expected anomalies based on mock data
+        expected_distance = torch.sum((mock_encoded_output - model.center) ** 2, dim=1)
+        expected_anomalies = (expected_distance >= model.chosen_threshold)
+
+        assert torch.all(anomalies.eq(expected_anomalies)), "Infer method did not correctly identify anomalies"

--- a/modules/sc-mesh-secure-deployment/src/2_0/features/ldpi/ldpi/inference.py
+++ b/modules/sc-mesh-secure-deployment/src/2_0/features/ldpi/ldpi/inference.py
@@ -58,9 +58,6 @@ class TrainedModel:
         self.near_max_threshold: Optional[float] = None
         self.max_threshold: Optional[float] = None
         self.hundred_one_threshold: Optional[float] = None
-
-        # Load trained model
-        self.store_models_path: str = f'features/ldpi/ldpi/training/output/{self.args.model_name}/'
         self._init_model()
 
         self.chosen_threshold: float = self._initialize_threshold()
@@ -75,16 +72,16 @@ class TrainedModel:
         try:
             print('Loading best model and center from saved state')
             # Load model from disk
-            model_save_path = os.path.join(self.store_models_path, 'best_model_with_center.pth')
+            model_save_path = os.path.join(self.args.store_models_path, 'best_model_with_center.pth')
             if self.quantized:
                 print('Loading quantized model')
                 if self.backend == 'qnnpack':
                     torch.backends.quantized.engine = 'qnnpack'
-                quantized_model_path = os.path.join(self.store_models_path, 'scripted_quantized_model.pth')
+                quantized_model_path = os.path.join(self.args.store_models_path, 'scripted_quantized_model.pth')
                 self.model = torch.jit.load(quantized_model_path, map_location=torch.device('cpu'))
             else:
                 print('Loading traced model')
-                traced_model_path = os.path.join(self.store_models_path, 'traced_model.pth')
+                traced_model_path = os.path.join(self.args.store_models_path, 'traced_model.pth')
                 self.model = torch.jit.load(traced_model_path, map_location=torch.device('cpu'))
 
             # Set model to eval mode

--- a/modules/sc-mesh-secure-deployment/src/2_0/features/ldpi/options.py
+++ b/modules/sc-mesh-secure-deployment/src/2_0/features/ldpi/options.py
@@ -85,6 +85,9 @@ class LDPIOptions:
         # Inference related arguments
         self.threshold_type: str = 'max'
 
+        # Model Path
+        self.store_models_path: str = f'features/ldpi/ldpi/training/output/ResCNN/'
+
     def parse_options(self) -> NoReturn:
         """
         Parse command-line arguments and update instance attributes.


### PR DESCRIPTION
Changes:
- Updated sniffer_test.py (include mac addresses in flow tuple, change mock_eth to Ethernet frame instance (mock not iterable), update file imports paths to automatically execute pytest)
- Updated trained_model_test.py (configure stored models' paths, specify compatible torch device to load models on comms devices)
- Add test files to required file path