### PR TITLE
MDM Agent Zeroconf IPv6 Support

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/mdm_agent.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/mdm_agent.py
@@ -175,7 +175,7 @@ class MdmAgent:
 
             try:
                 # Create a socket connection to the server
-                sock = socket.create_connection((hostname, port))
+                sock = socket.create_connection((hostname, port), timeout=20)
 
                 # Create an SSL context and load the certificate, key, and CA files
                 context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
@@ -369,7 +369,7 @@ class MdmAgent:
                 params={"device_id": self.__device_id},
                 cert=(self.__certificate_file, self.__keyfile),
                 verify=self.__ca,
-                timeout=2,
+                timeout=20,
             )
         except requests.exceptions.ConnectionError as err:
             self.logger.error(
@@ -642,7 +642,7 @@ class MdmAgent:
                 params=data,
                 cert=(self.__certificate_file, self.__keyfile),
                 verify=self.__ca,
-                timeout=2,
+                timeout=20,
             )
         except FileNotFoundError as e:
             self.logger.error("Certificate file not found: %s", e)
@@ -694,7 +694,7 @@ class MdmAgent:
                 json=data,
                 cert=(self.__certificate_file, self.__keyfile),
                 verify=self.__ca,
-                timeout=2,
+                timeout=20,
             )
         except FileNotFoundError as e:
             self.logger.error("Certificate file not found: %s", e)

--- a/modules/sc-mesh-secure-deployment/src/nats/src/comms_service_discovery.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/comms_service_discovery.py
@@ -10,7 +10,7 @@ import logging
 import inspect
 
 import netifaces
-from zeroconf import ServiceStateChange, Zeroconf
+from zeroconf import ServiceStateChange, Zeroconf, IPVersion
 from zeroconf import ServiceBrowser, ServiceInfo
 
 
@@ -94,9 +94,9 @@ class CommsServiceMonitor:
         self.running = True
         if self.interface:
             addresses = self.__get_ip_addresses(self.interface)
-            self.zeroconf = Zeroconf(interfaces=addresses)
+            self.zeroconf = Zeroconf(interfaces=addresses, ip_version=IPVersion.All)
         else:
-            self.zeroconf = Zeroconf()
+            self.zeroconf = Zeroconf(ip_version=IPVersion.All)
 
         self.service_browser = ServiceBrowser(
             self.zeroconf,


### PR DESCRIPTION
This PR enables IPv6 support in the Zeroconf Python module.

Unless explicitly stated at the object creation, Zeroconf is IPv4 only if not passing an interface that has an IPv6 address. Relevant function in Zeroconf code is `autodetect_ip_version()`

Also, timeouts for connecting to the MDM Server have been increased from 2 to 20 seconds, as the devices might fail to do upload/downloads on slow/unstable networks

:1st_place_medal: 