### PR TITLE
Fix crash in MDM agent caused by interface no name

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
@@ -680,7 +680,7 @@ class CBMAAdaptation(object):
                     has_upper_certificate = has_upper_certificate and 0
                 else:
                     self.logger.warning(
-                        "No cbma certificate for interface %s", interface.name
+                        "No cbma certificate for interface %s", interface.interface_name
                     )
                     continue
 


### PR DESCRIPTION
Jira-Id: SECO-4692