### PR TITLE
Fix missing index variable in MDM Agent Global IPv6 assignment

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
@@ -635,6 +635,7 @@ class CBMAAdaptation(object):
                 self.logger.debug(
                     f"New {interface_name} Global IPv6 address: {new_address}"
                 )
+                index = ip.link_lookup(ifname=interface_name)[0]
 
                 # Add the modified IPv6 address to the interface
                 ip.addr("add", index=index, address=new_address, prefixlen=64)


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/tiiuae/mesh_com/pull/429 that prevented the assignment of global IPv6 addresses on MDM agent startup :adhesive_bandage: 