### PR TITLE
Add Github workflow to autocreate VERSION files on main and develop

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,31 @@
+name: Version File
+on:
+  push:
+    branches:
+      - main
+      - develop
+jobs:
+  version-file:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      - name: Create VERSION file
+        run: |
+          {
+            echo GIT_SHA=$GITHUB_SHA
+            echo EPOCH_TIMESTAMP=$(date +%s)
+            echo PRECISE_DATE_TIMESTAMP=\"$(date "+%Y-%m-%d - %H:%M:%S.%N")\"
+          } > VERSION
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'Update VERSION'
+          disable_globbing: true
+          file_pattern: VERSION


### PR DESCRIPTION
This PR adds the same functionality used in CBMA repo for the autocreation of a VERSION file containing the commit hash and timestamps on every commit done to the develop and main branches :secret: 