### PR TITLE
Mess bridge hotfix

### DIFF
--- a/common/scripts/slaac.sh
+++ b/common/scripts/slaac.sh
@@ -69,7 +69,19 @@ chmod 644 "/run/radvd@$INTERFACE.conf"
 # Write the radvd configuration to the file
 echo "Writing configuration to $RADVD_CONF_FILE..."
 cat > "$RADVD_CONF_FILE" << EOF
-interface $INTERFACE
+# Running different radvd instances on different br-lan ports is the desired
+# design and it was working but for some reason br-lan stopped forwarding
+# router advertisements from said port to bat0 and thus the rest of the mesh:
+# in other words leaking RAs, which is not what we want eventually but which is
+# what we need to make things work while we wait for brouting implementation.
+# I tried to debug this but could not quickly find an obvious reason why the
+# temporarily-desired leakage stopped working so here is a quick & dirty
+# workaround as we'll get brouting soon anyway: force leakage by running radvd
+# directly on the whole switch; I did test that several instances of radvd do
+# not mind running on the same interface, at least it worked for me :-)   Seb
+#
+#interface $INTERFACE
+interface br-lan
 {
         IgnoreIfMissing on;
         AdvSendAdvert on;

--- a/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/create_bridge.sh
+++ b/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/create_bridge.sh
@@ -15,7 +15,7 @@ create_bridge_if_needed()
         ip link set dev "$MACBR_NAME" alias "$LEVEL MACVLAN/MACsec bridge above $BASE_INTERFACE_NAME" || true
         ip link set dev "$MACBR_NAME" addrgenmode eui64 || true
         ip link set dev "$MACBR_NAME" type bridge no_linklocal_learn 1 || true
-        ebtables -t nat -N "$MACBR_NAME" || true
+        ebtables -t nat -N "$MACBR_NAME" -P DROP || true
         ebtables -t nat -A OUTPUT -j "$MACBR_NAME" --logical-out "$MACBR_NAME" || true
         if ! ip link set dev "$MACBR_NAME" up \
            || ! batctl meshif "$BATMAN_NAME" interface add "$MACBR_NAME"; then


### PR DESCRIPTION
Traffic multiplication appears to be due to a regression in the Lower/Upper Mess Bridge's (lmb/umb) even though they appear to be correctly configured in terms of forwarding database (bridge fdb) and port isolation (ip -d link show) so here is a bruteforce hotfix just dropping any traffic that should not be happening anyway.

WARNING: untested with more than 2 devices (which is required to be able to reproduced the issue) as I do not have access to more than 2 right now, but FWIW this hotfix does not seem to break anything at least between 2 devices.