### PR TITLE
Mess bridge hotfix2

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/cleanup_mess.sh
+++ b/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/cleanup_mess.sh
@@ -7,9 +7,8 @@ export SCN='/sys/class/net'
 
 cleanup_macscbpad_interface()
 {
-	ebtables -t nat -D "$MACBR_NAME" -o "$MACSCBPAD_NAME" -j dnat --to-destination "$REMOTE_MAC"
 	ebtables -t nat -D PREROUTING -i "$MACSCBPAD_NAME" -j dnat --to-destination ff:ff:ff:ff:ff:ff
-	ebtables -t nat -D "$MACBR_NAME" -o "$MACSCBPAD_NAME" -d '!' Broadcast -j DROP
+	ebtables -t nat -D "$MACBR_NAME" -o "$MACSCBPAD_NAME" -d Broadcast -j dnat --to-destination "$REMOTE_MAC"
 	ip link delete "$MACSCBPAD_NAME"
 }
 
@@ -26,7 +25,7 @@ cleanup_macscbub_interface()
 
 cleanup_macsec_interface()
 {
-	ebtables -t nat -D "$MACBR_NAME" -o "$MACSEC_NAME" -d Broadcast -j DROP
+	ebtables -t nat -D "$MACBR_NAME" -o "$MACSEC_NAME" -d "$REMOTE_MAC" -j ACCEPT
 	ip link delete "$MACSEC_NAME"
 }
 

--- a/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/create_bridge.sh
+++ b/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/create_bridge.sh
@@ -15,7 +15,7 @@ create_bridge_if_needed()
         ip link set dev "$MACBR_NAME" alias "$LEVEL MACVLAN/MACsec bridge above $BASE_INTERFACE_NAME" || true
         ip link set dev "$MACBR_NAME" addrgenmode eui64 || true
         ip link set dev "$MACBR_NAME" type bridge no_linklocal_learn 1 || true
-        ebtables -t nat -N "$MACBR_NAME" || true
+        ebtables -t nat -N "$MACBR_NAME" -P DROP || true
         ebtables -t nat -A OUTPUT -j "$MACBR_NAME" --logical-out "$MACBR_NAME" || true
         if ! ip link set dev "$MACBR_NAME" up \
            || ! batctl meshif "$BATMAN_NAME" interface add "$MACBR_NAME"; then


### PR DESCRIPTION
(Redoing the PR notably because I mistakenly created https://github.com/tiiuae/mesh_com/pull/454 as a branch of a previous PR branch and don't want to risk messing with rebasing etc)

Traffic multiplication appears to be due to a regression in the Lower/Upper Mess Bridge's (lmb/umb) even though they appear to be correctly configured in terms of forwarding database (bridge fdb) and port isolation (ip -d link show) so here is a bruteforce hotfix just dropping any traffic that should not be happening anyway.

WARNING: untested with more than 2 devices (which is required to be able to reproduced the issue) as I do not have access to more than 2 right now, but FWIW this hotfix does not seem to break anything at least between 2 devices.