### PR TITLE
Fix old pyroute error + increase radio setup timeouts in MDM Agent

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
@@ -660,9 +660,9 @@ class CBMAAdaptation(object):
         # interface exists and is ready to be added to bridge.
         for interface_name in self.__comms_ctrl.settings.mesh_vif:
             self.logger.debug("mesh_vif: %s", interface_name)
-            timeout = 3
+            timeout = 5
             if interface_name.startswith("halow"):
-                timeout = 10
+                timeout = 20
             self.__wait_for_interface(interface_name, timeout)
 
         for mode in self.__comms_ctrl.settings.mode:

--- a/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/cbma_adaptation.py
@@ -15,7 +15,6 @@ import fnmatch
 import ipaddress
 import errno
 from pyroute2 import IPRoute, NetlinkError, arp  # type: ignore[import-not-found, import-untyped]
-from pyroute2.netlink.exceptions import NetlinkDumpInterrupted
 
 from src import cbma_paths
 from src.comms_controller import CommsController
@@ -287,7 +286,7 @@ class CBMAAdaptation(object):
             try:
                 ip_links = ip.get_links()
                 break
-            except NetlinkDumpInterrupted:
+            except NetlinkError:
                 time.sleep(1)
 
         for link in ip_links:

--- a/modules/sc-mesh-secure-deployment/src/nats/src/comms_if_monitor.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/comms_if_monitor.py
@@ -8,8 +8,7 @@ from typing import Callable, List, Dict
 import subprocess
 import time
 from copy import deepcopy
-from pyroute2 import IPRoute
-from pyroute2.netlink.exceptions import NetlinkDumpInterrupted
+from pyroute2 import IPRoute, NetlinkError
 
 DUMMY_INTERFACE_NAME = 'ifdummy0'
 
@@ -31,7 +30,7 @@ class CommsInterfaceMonitor:
             try:
                 ip_links = self.__ipr.get_links()
                 break
-            except NetlinkDumpInterrupted:
+            except NetlinkError:
                 time.sleep(1)
 
         for link in ip_links:


### PR DESCRIPTION
The title :crown: 

In a previous PR, handling `NLM_F_DUMP_INTR` via `NetlinkDumpInterrupted` in pyroute2 was introduced, but this error handler is not available in pyroute2 0.5.7, so we are replacing it with the generic `NetlinkError`.

Also there seems to be some issue in not having the `halow` interface ready in CMs, so the timeout for this check has been increased to hopefully workaround this issue

:cd: 