### PR TITLE
MDM Agent: Upgrade hardcoded fallback mDNS IPv6 to <prefix>::100

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/mdm_agent.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/mdm_agent.py
@@ -80,7 +80,7 @@ class MdmAgent:
             self.__lock
         )
         self.__url: str = "defaultmdm.local:5000"  # mDNS callback updates this one
-        self.__fallback_url: str = f"[{Constants.IPV6_WHITE_PREFIX.value}::1]:5000"
+        self.__fallback_url: str = f"[{Constants.IPV6_WHITE_PREFIX.value}::100]:5000"
 
         self.service_monitor = comms_service_discovery.CommsServiceMonitor(
             service_name="MDM Service",


### PR DESCRIPTION
The title :arrow_up: 

Change needed after upgrading the MDM Servers to use VRRP :mushroom: 

Edit:

Bit more context, if the mDNS resolution fails the fallback IPv6 will be used to resolve `defaultmdm.local` but then the certificate won't match, thus resulting in the following error:
> 2024-07-11 09:50:21,415 :: comms.controller.mdm_agent :: ERROR    :: HTTP request failed with error: HTTPSConnectionPool(host='fdbb:1ef7:9d6f:e05d::1', port=5000): Max retries exceeded with url: /public/get_device_config/mesh_conf?device_id=04f021bf893310000000744cf195 (Caused by SSLError(SSLCertVerificationError("hostname 'fdbb:1ef7:9d6f:e05d::1' doesn't match 'defaultmdm.local'")))
