### PR TITLE
MDM Agent: Use auto-calculated buffer size in IPRoute.get() call

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/src/comms_if_monitor.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/comms_if_monitor.py
@@ -73,7 +73,9 @@ class CommsInterfaceMonitor:
             try:
                 # Hox! get() is a blocking call thus stop() doesn't
                 # have much affect when execution is blocked within get().
-                messages = self.__ipr.get()
+                # TODO - Using bufsize=-1 is broken in pyroute2 0.7.12
+                # NOTE - bufsize=-1 required to prevent "No buffer space available" error
+                messages = self.__ipr.get(bufsize=-1)
                 for msg in messages:
                     if msg["event"] == "RTM_NEWLINK" or msg["event"] == "RTM_DELLINK":
                         interface_info = self.__get_interface_info(msg)


### PR DESCRIPTION
The title :up: 

Apparently in some cases the call to IPRoute.get() might result in `No buffer space available`:
>   File "/opt/nats/src/comms_if_monitor.py", line 67, in monitor_interfaces
    messages = self.__ipr.get()
>  File "/usr/lib/python3.9/site-packages/pyroute2/netlink/nlsocket.py", line 376, in get
>  File "/usr/lib/python3.9/site-packages/pyroute2/netlink/nlsocket.py", line 776, in get
>  File "/usr/lib/python3.9/site-packages/pyroute2/netlink/nlsocket.py", line 554, in recv_ft
> OSError: [Errno 105] No buffer space available

To workaround this issue we are making the `bufsize` autodetectable.

It shall be noted that this feature seems to be broken in `pyroute2` version 0.7.12, but the versions included in iMX8 and RPIOS are lower, so a TODO has been added in the line for future changes.

Documentation: https://docs.pyroute2.org/nlsocket.html#pyroute2.netlink.nlsocket.NetlinkSocketBaseSafe.get

Jira-ID: SECO-6713

:crystal_ball: 