### PR TITLE
SECO-7322: mesh rssi threshold for halow to -105dbm

### DIFF
--- a/common/scripts/mesh-11s_nats.sh
+++ b/common/scripts/mesh-11s_nats.sh
@@ -179,6 +179,7 @@ EOF
       # /usr/local/bin/cli_app set txpwr fixed 23
       /usr/local/bin/cli_app set gi long
       /usr/local/bin/cli_app set support_ch_width 1
+      /usr/local/bin/cli_app set mesh_rssi_threshold -105
 
       # Batman parameters
       if [ "$routing_algo" == "batman-adv" ]; then


### PR DESCRIPTION
halow range is not good due to default lower mesh rssi threshold. Applying -105dbm as mesh rssi threshold