### PR TITLE
SECO-7824: bat0 OGM interval to 500ms to handle mobility use cases

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/src/bat_ctrl_utils.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/bat_ctrl_utils.py
@@ -127,8 +127,9 @@ class BatCtrlUtils(object):
                 ["batctl", "meshif", batman_if, "fragmentation", "1"], check=True
             )
 
+            ogm_interval = "5000" if is_upper else "500"
             subprocess.run(
-                ["batctl", "meshif", batman_if, "orig_interval", "5000"], check=True
+                ["batctl", "meshif", batman_if, "orig_interval", ogm_interval], check=True
             )
 
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
bat0 OGM interval of 500ms is required to handle mobility use case. bat1 OGM remain as 5 sec.