### PR TITLE
Change br-lan control

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/conf/default_ms_config.yaml
+++ b/modules/sc-mesh-secure-deployment/src/nats/conf/default_ms_config.yaml
@@ -21,10 +21,16 @@ CBMA:
     - sap0
     - sta0
     - wfd0
-  white_interfaces: 
+    - end0
+    - end1
+  white_interfaces:
   red_interfaces:
     - wlan1
     - usb0
+    - eth0
+    - end0
+    - end1
+    - lan1
 
 BATMAN:
   routing_algo: BATMAN_V
@@ -35,17 +41,17 @@ BATMAN:
     hardif:
       halow1: 20
 
-VLAN:
+#VLAN:
 # Remember that IP address definitions for such interface that is added to
 # CBMA's red_interfaces list (i.e. br-lan bridge) are not effective.
-  vlan_black:
-    parent_interface: eth0
-    vlan_id: 100
-    ipv4_address: 192.168.1.1
-    ipv4_subnet_mask: 255.255.255.0
-    ipv6_local_address: fe80::192.168.1.1
-    ipv6_prefix_length: 64
-  vlan_red:
-    parent_interface: eth0
-    vlan_id: 200
+#  vlan_black:
+#    parent_interface: eth0
+#    vlan_id: 100
+#    ipv4_address: 192.168.1.1
+#    ipv4_subnet_mask: 255.255.255.0
+#    ipv6_local_address: fe80::192.168.1.1
+#    ipv6_prefix_length: 64
+#  vlan_red:
+#    parent_interface: eth0
+#    vlan_id: 200
   


### PR DESCRIPTION
Jira-ID: SECO-8033, SECO-8006

Bridge control changed so that br-lan is not deleted when CBMA/MDM Agent is stopped. Also trying to use static MAC for the bridge using MAC from some physical interfaces (osf or ethernet) that is not configured to lower CBMA. Default configs changed so that eth0/end0/end or lan1 interface is added to bridge.