### PR TITLE
Update base MTU size

### DIFF
--- a/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/constants.rc
+++ b/modules/sc-mesh-secure-deployment/src/nats/cbma/scripts/mess/constants.rc
@@ -4,5 +4,5 @@ export MACSEC_OVERHEAD=16
 # needs more testing, an overhead of 32 might even occur if batman-adv uses 4 address mode
 export BATMAN_OVERHEAD=48
 
-export HOPEFULLY1500=1500
+export HOPEFULLY1500=1372
 export SCN='/sys/class/net'

--- a/modules/sc-mesh-secure-deployment/src/nats/conf/default_ms_config.yaml
+++ b/modules/sc-mesh-secure-deployment/src/nats/conf/default_ms_config.yaml
@@ -3,7 +3,7 @@
 ###########################
 
 # hostname of the device
-hostname: nixos
+hostname: buildroot
 
 # All the interfaces are black by default.
 # Excluded interfaces or interfaces without macsec certificates are not added to lower CBMA.

--- a/modules/sc-mesh-secure-deployment/src/nats/src/constants.py
+++ b/modules/sc-mesh-secure-deployment/src/nats/src/constants.py
@@ -92,6 +92,6 @@ class Constants(Enum):
     FAIL_POLLING_TIME_SECONDS: int = 1
 
     # MTU sizes
-    BASE_MTU_SIZE: int = 1500
+    BASE_MTU_SIZE: int = 1372
     MACSEC_OVERHEAD: int = 16
     BATMAN_OVERHEAD: int = 48


### PR DESCRIPTION
Jira-ID: SECO-9738

- Base MTU size changed from 1500 to 1372
- Default hostname changed from nixos to buildroot